### PR TITLE
Support helm releases in non-"cert-manager" namespaces.

### DIFF
--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -30,17 +30,19 @@ spec:
           periodSeconds: 7
         command: ["cert-manager-approver-policy"]
         args:
-          - "--log-level={{.Values.app.logLevel}}"
+          - --log-level={{.Values.app.logLevel}}
+
           {{- range .Values.app.extraArgs }}
-          - "{{ . }}"
+          - {{ . }}
           {{- end  }}
 
-          - "--metrics-bind-address=:{{.Values.app.metrics.port}}"
-          - "--readiness-probe-bind-address=:{{.Values.app.readinessProbe.port}}"
+          - --metrics-bind-address=:{{.Values.app.metrics.port}}
+          - --readiness-probe-bind-address=:{{.Values.app.readinessProbe.port}}
 
-          - "--webhook-host={{.Values.app.webhook.host}}"
-          - "--webhook-port={{.Values.app.webhook.port}}"
-          - "--webhook-ca-secret-namespace={{.Release.Namespace}}"
+          - --webhook-host={{.Values.app.webhook.host}}
+          - --webhook-port={{.Values.app.webhook.port}}
+          - --webhook-service-name={{ include "cert-manager-approver-policy.name" . }}
+          - --webhook-ca-secret-namespace={{.Release.Namespace}}
 
         {{- if .Values.volumeMounts }}
         volumeMounts:

--- a/pkg/internal/cmd/cmd.go
+++ b/pkg/internal/cmd/cmd.go
@@ -73,6 +73,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				Log:                    opts.Logr,
 				Webhooks:               registry.Shared.Webhooks(),
 				WebhookCertificatesDir: opts.Webhook.CertDir,
+				ServiceName:            opts.Webhook.ServiceName,
 				CASecretNamespace:      opts.Webhook.CASecretNamespace,
 				Manager:                mgr,
 			}); err != nil {

--- a/pkg/internal/cmd/options/options.go
+++ b/pkg/internal/cmd/options/options.go
@@ -83,6 +83,9 @@ type Webhook struct {
 	// stored with the names `tls.crt` and `tls.key` respectively.
 	CertDir string
 
+	// ServiceName is the service that exposes the Webhook server.
+	ServiceName string
+
 	// CASecretNamespace is the namespace that the
 	// cert-manager-approver-policy-tls Secret is stored.
 	CASecretNamespace string
@@ -166,9 +169,13 @@ func (o *Options) addWebhookFlags(fs *pflag.FlagSet) {
 		"webhook-port", 6443,
 		"Port to serve webhook.")
 
+	fs.StringVar(&o.Webhook.ServiceName,
+		"webhook-service-name", "cert-manager-approver-policy",
+		"Name of the Kubernetes Service that exposes the Webhook's server.")
+
 	fs.StringVar(&o.Webhook.CASecretNamespace,
 		"webhook-ca-secret-namespace", "cert-manager",
-		"Namespace that the cert-manager-approver-policy-tls Secret is stored..")
+		"Namespace that the cert-manager-approver-policy-tls Secret is stored.")
 
 	fs.StringVar(&o.Webhook.CertDir,
 		"webhook-certificate-dir", "/tmp",

--- a/pkg/internal/webhook/webhook.go
+++ b/pkg/internal/webhook/webhook.go
@@ -48,6 +48,11 @@ type Options struct {
 	// cert-manager-approver-policy-tls Secret is stored.
 	CASecretNamespace string
 
+	// ServiceName is the name of the service that exposes the webhook server.
+	// This name will be used as the DNS SAN entry to the webhook's serving
+	// certificate.
+	ServiceName string
+
 	// Manager is the shared controller-runtime manager used by this
 	// approver-policy instance. The webhook will register its endpoints and
 	// runnables against.
@@ -65,6 +70,7 @@ func Register(ctx context.Context, opts Options) error {
 		RestConfig:             opts.Manager.GetConfig(),
 		WebhookCertificatesDir: opts.WebhookCertificatesDir,
 		CASecretNamespace:      opts.CASecretNamespace,
+		ServiceName:            opts.ServiceName,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to run webhook tls bootstrap process: %w", err)


### PR DESCRIPTION
Adds support for releasing approver-policy is a different namespace by
exposing the service name of the webhook, and piping the secret
namespace to the tls manager.

This PR is a no-op except approver-policy will now work when releasing in a namespace that is not cert-manager.

/assign @irbekrm 

fixes #42 