### PR TITLE
Adds log as a parameter to the Approver Prepare signature.

### DIFF
--- a/pkg/approver/allowed/allowed.go
+++ b/pkg/approver/allowed/allowed.go
@@ -19,6 +19,7 @@ package allowed
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -51,7 +52,7 @@ func (a Allowed) RegisterFlags(_ *pflag.FlagSet) {
 }
 
 // Prepare is a no-op, Allowed doesn't need to prepare anything.
-func (a Allowed) Prepare(_ context.Context, _ manager.Manager) error {
+func (a Allowed) Prepare(_ context.Context, _ logr.Logger, _ manager.Manager) error {
 	return nil
 }
 

--- a/pkg/approver/approver.go
+++ b/pkg/approver/approver.go
@@ -19,6 +19,7 @@ package approver
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -36,7 +37,7 @@ type Interface interface {
 
 	// Prepare can be used by Approvers for registering extra Kubernetes
 	// controllers, adding health checks, or other controller-runtime runnables.
-	Prepare(context.Context, manager.Manager) error
+	Prepare(context.Context, logr.Logger, manager.Manager) error
 
 	// Evaluator is responsible for executing evaluations on whether a request
 	// should be denied or not.

--- a/pkg/approver/constraints/constraints.go
+++ b/pkg/approver/constraints/constraints.go
@@ -19,6 +19,7 @@ package constraints
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -49,7 +50,7 @@ func (c Constraints) RegisterFlags(_ *pflag.FlagSet) {
 }
 
 // Prepare is a no-op, constraints doesn't need to prepare anything.
-func (c Constraints) Prepare(_ context.Context, _ manager.Manager) error {
+func (c Constraints) Prepare(_ context.Context, _ logr.Logger, _ manager.Manager) error {
 	return nil
 }
 

--- a/pkg/approver/fake/approver.go
+++ b/pkg/approver/fake/approver.go
@@ -19,6 +19,7 @@ package fake
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -31,7 +32,7 @@ var _ approver.Interface = &FakeApprover{}
 // pre-determined response.
 type FakeApprover struct {
 	registerFlagsFn func(*pflag.FlagSet)
-	prepareFn       func(context.Context, manager.Manager) error
+	prepareFn       func(context.Context, logr.Logger, manager.Manager) error
 	*FakeEvaluator
 	*FakeWebhook
 	*FakeReconciler
@@ -60,7 +61,7 @@ func (f *FakeApprover) WithRegisterFlags(fn func(*pflag.FlagSet)) *FakeApprover 
 	return f
 }
 
-func (f *FakeApprover) WithPrepare(fn func(context.Context, manager.Manager) error) *FakeApprover {
+func (f *FakeApprover) WithPrepare(fn func(context.Context, logr.Logger, manager.Manager) error) *FakeApprover {
 	f.prepareFn = fn
 	return f
 }
@@ -69,6 +70,6 @@ func (f *FakeApprover) RegisterFlags(pf *pflag.FlagSet) {
 	f.registerFlagsFn(pf)
 }
 
-func (f *FakeApprover) Prepare(ctx context.Context, mgr manager.Manager) error {
-	return f.prepareFn(ctx, mgr)
+func (f *FakeApprover) Prepare(ctx context.Context, log logr.Logger, mgr manager.Manager) error {
+	return f.prepareFn(ctx, log, mgr)
 }

--- a/pkg/internal/cmd/cmd.go
+++ b/pkg/internal/cmd/cmd.go
@@ -83,7 +83,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			log.Info("preparing approvers...")
 			for _, approver := range registry.Shared.Approvers() {
 				log.Info("preparing approver...", "approver", approver.Name())
-				if err := approver.Prepare(ctx, mgr); err != nil {
+				if err := approver.Prepare(ctx, opts.Logr, mgr); err != nil {
 					return fmt.Errorf("failed to prepare approver %q: %w", approver.Name(), err)
 				}
 			}


### PR DESCRIPTION
 This helps approvers to use a consistent logger which is a child of the main
approver-policy manager.

/assign @wallrj 