### PR TITLE
Fix broken HTML in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-<p align="center"><img src="https://github.com/jetstack/cert-manager/blob/master/logo/logo.png" width="250x" /></p>
-</a>
-<a href="https://godoc.org/github.com/cert-manager/approver-policy"><img src="https://godoc.org/github.com/cert-manager/approver-policy?status.svg"></a>
-<a href="https://goreportcard.com/report/github.com/cert-manager/approver-policy"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/cert-manager/approver-policy" /></a></p>
+<p align="center">
+  <img src="https://github.com/jetstack/cert-manager/blob/master/logo/logo.png" width="250x" alt="cert-manager project logo" />
+</p>
+<p align="center">
+  <a href="https://godoc.org/github.com/cert-manager/approver-policy"><img src="https://godoc.org/github.com/cert-manager/approver-policy?status.svg" alt="approver-policy godoc"></a>
+  <a href="https://goreportcard.com/report/github.com/cert-manager/approver-policy"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/cert-manager/approver-policy" /></a>
+  <a href="https://artifacthub.io/packages/search?repo=cert-manager"><img alt="Artifact Hub" src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cert-manager" /></a>
+</p>
 
 # approver-policy
 


### PR DESCRIPTION
I noticed this while changing istio-csr (in [this PR](https://github.com/cert-manager/istio-csr/pull/116)) and it also applies here!

Also adds an artifacthub badge and some alt text for accessibility.