### PR TITLE
fix hello.world example policy,  commonName must be an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ metadata:
   name: test-policy
 spec:
   allowed:
-    commonName: "hello.world"
-    required: true
+    commonName:
+      value: "hello.world"
+      required: true
   selector:
     # Select all IssuerRef
     issuerRef: {}


### PR DESCRIPTION
When trying the hello.world policy example in `README.md`, the following error occurs:

```bash
$ oc create -f hello.yaml
The CertificateRequestPolicy "test-policy" is invalid: spec.allowed.commonName: Invalid value: "string": spec.allowed.commonName in body must be of type object: "string"
$
```

This patch fixes the problem by changing `spec.commonName` in the example policy from a string to an object containing the fields `value` and `required`.