### PR TITLE
Fixes the spelling of `WildcardMatchs` -> `WildcardMatches`

### DIFF
--- a/pkg/internal/approver/allowed/evaluator.go
+++ b/pkg/internal/approver/allowed/evaluator.go
@@ -58,7 +58,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.Subject.CommonName) > 0 {
 		if allowed.CommonName == nil || allowed.CommonName.Value == nil {
 			el = append(el, field.Invalid(fldPath.Child("commonName", "value"), csr.Subject.CommonName, "nil"))
-		} else if !util.WildcardMatchs(*allowed.CommonName.Value, csr.Subject.CommonName) {
+		} else if !util.WildcardMatches(*allowed.CommonName.Value, csr.Subject.CommonName) {
 			el = append(el, field.Invalid(fldPath.Child("commonName", "value"), csr.Subject.CommonName, *allowed.CommonName.Value))
 		}
 	} else if allowed.CommonName != nil && allowed.CommonName.Required != nil && *allowed.CommonName.Required {
@@ -215,7 +215,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.Subject.SerialNumber) > 0 {
 		if allowedSub == nil || allowedSub.SerialNumber == nil {
 			el = append(el, field.Invalid(fldPath.Child("serialNumber", "value"), csr.Subject.SerialNumber, "nil"))
-		} else if !util.WildcardMatchs(*allowedSub.SerialNumber.Value, csr.Subject.SerialNumber) {
+		} else if !util.WildcardMatches(*allowedSub.SerialNumber.Value, csr.Subject.SerialNumber) {
 			el = append(el, field.Invalid(fldPath.Child("serialNumber", "value"), csr.Subject.SerialNumber, *allowedSub.SerialNumber.Value))
 		}
 	} else if allowedSub != nil && allowedSub.SerialNumber != nil && allowedSub.SerialNumber.Required != nil && *allowedSub.SerialNumber.Required {

--- a/pkg/internal/approver/manager/predicate/predicate.go
+++ b/pkg/internal/approver/manager/predicate/predicate.go
@@ -62,13 +62,13 @@ func SelectorIssuerRef(_ context.Context, cr *cmapi.CertificateRequest, policies
 		issRefSel := policy.Spec.Selector.IssuerRef
 		issRef := cr.Spec.IssuerRef
 
-		if issRefSel.Name != nil && !util.WildcardMatchs(*issRefSel.Name, issRef.Name) {
+		if issRefSel.Name != nil && !util.WildcardMatches(*issRefSel.Name, issRef.Name) {
 			continue
 		}
-		if issRefSel.Kind != nil && !util.WildcardMatchs(*issRefSel.Kind, issRef.Kind) {
+		if issRefSel.Kind != nil && !util.WildcardMatches(*issRefSel.Kind, issRef.Kind) {
 			continue
 		}
-		if issRefSel.Group != nil && !util.WildcardMatchs(*issRefSel.Group, issRef.Group) {
+		if issRefSel.Group != nil && !util.WildcardMatches(*issRefSel.Group, issRef.Group) {
 			continue
 		}
 		matchingPolicies = append(matchingPolicies, policy)

--- a/pkg/internal/util/wildcard.go
+++ b/pkg/internal/util/wildcard.go
@@ -43,7 +43,7 @@ func WildcardSubset(patterns, members []string) bool {
 // ('*').
 func WildcardContains(patterns []string, member string) bool {
 	for _, pattern := range patterns {
-		if WildcardMatchs(pattern, member) {
+		if WildcardMatches(pattern, member) {
 			return true
 		}
 	}
@@ -51,9 +51,9 @@ func WildcardContains(patterns []string, member string) bool {
 	return false
 }
 
-// WildcardMatchs will return true if the given string matches the pattern.
+// WildcardMatches will return true if the given string matches the pattern.
 // Pattern is a string which supports wildcards ('*').
-func WildcardMatchs(pattern, str string) bool {
+func WildcardMatches(pattern, str string) bool {
 	if len(pattern) == 0 {
 		return len(str) == 0
 	}

--- a/pkg/internal/util/wildcard_test.go
+++ b/pkg/internal/util/wildcard_test.go
@@ -228,7 +228,7 @@ func Test_WildcardContains(t *testing.T) {
 	}
 }
 
-func Test_WildcardMatchs(t *testing.T) {
+func Test_WildcardMatches(t *testing.T) {
 	tests := map[string]struct {
 		pattern string
 		text    string
@@ -297,7 +297,7 @@ func Test_WildcardMatchs(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if match := WildcardMatchs(test.pattern, test.text); match != test.exp {
+			if match := WildcardMatches(test.pattern, test.text); match != test.exp {
 				t.Errorf("unexpected match (%q, %q): exp=%t got=%t",
 					test.pattern, test.text, test.exp, match)
 			}


### PR DESCRIPTION
Opened base on https://github.com/cert-manager/approver-policy/pull/96#discussion_r918882656

/assign @munnerz 