### PR TITLE
Adds the Helm value `.Values.app.webhook.certificateDir`

### DIFF
--- a/deploy/charts/approver-policy/Chart.yaml
+++ b/deploy/charts/approver-policy/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 - https://github.com/cert-manager/approver-policy
 
 appVersion: v0.4.0
-version: v0.4.1
+version: v0.4.2

--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -1,6 +1,6 @@
 # cert-manager-approver-policy
 
-![Version: v0.4.1](https://img.shields.io/badge/Version-v0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.0](https://img.shields.io/badge/AppVersion-v0.4.0-informational?style=flat-square)
+![Version: v0.4.2](https://img.shields.io/badge/Version-v0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.0](https://img.shields.io/badge/AppVersion-v0.4.0-informational?style=flat-square)
 
 A Helm chart for cert-manager-approver-policy
 
@@ -29,6 +29,7 @@ A Helm chart for cert-manager-approver-policy
 | app.metrics.service.servicemonitor | object | `{"enabled":false,"interval":"10s","labels":{},"prometheusInstance":"default","scrapeTimeout":"5s"}` | ServiceMonitor resource for this Service. |
 | app.metrics.service.type | string | `"ClusterIP"` | Service type to expose metrics. |
 | app.readinessProbe.port | int | `6060` | Container port to expose approver-policy HTTP readiness probe on default network interface. |
+| app.webhook.certificateDir | string | `"/tmp"` | Directory to read and store the webhook TLS certificate key pair. |
 | app.webhook.host | string | `"0.0.0.0"` | Host that the webhook listens on. |
 | app.webhook.port | int | `6443` | Port that the webhook listens on. |
 | app.webhook.service | object | `{"type":"ClusterIP"}` | Type of Kubernetes Service used by the Webhook |

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
           - --webhook-port={{.Values.app.webhook.port}}
           - --webhook-service-name={{ include "cert-manager-approver-policy.name" . }}
           - --webhook-ca-secret-namespace={{.Release.Namespace}}
+          - --webhook-certificate-dir={{.Values.app.webhook.certificateDir}}
 
         {{- if .Values.volumeMounts }}
         volumeMounts:

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -56,6 +56,8 @@ app:
     port: 6443
     # -- Timeout of webhook HTTP request.
     timeoutSeconds: 5
+    # -- Directory to read and store the webhook TLS certificate key pair.
+    certificateDir: /tmp
     # -- Type of Kubernetes Service used by the Webhook
     service:
       type: ClusterIP


### PR DESCRIPTION
This PR add a helm value to expose configuring where the webhook certificate key pair is read and stored.

Defaults to `/tmp`.

Updates the `Chart.yaml` version ready for release.