### PR TITLE
Automatically push Docker images when release when tags are pushed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,49 @@
+name: release
+on:
+  push:
+    tags:
+      - "v*"
+env:
+  VERSION: ${{ github.ref_name }}
+  IMAGE: quay.io/jetstack/cert-manager-approver-policy:${{ github.ref_name }}
+jobs:
+  docker-image:
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
+          push: true
+          tags: ${{ env.IMAGE }}
+          build-args: |
+            VERSION=${{ env.VERSION }}
+
+  github-release:
+    runs-on: ubuntu-22.04
+    needs:
+      - docker-image
+    steps:
+      - id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          release_name: ${{ env.VERSION }}
+          draft: true
+          prerelease: true
+          body: |
+            Docker Image: `${{ env.IMAGE }}`

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,9 @@ COPY pkg/ pkg/
 
 RUN go mod download
 
+ARG VERSION
 # Build
-RUN make build
+RUN make build VERSION=${VERSION}
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/README.md
+++ b/README.md
@@ -22,3 +22,24 @@ signed by cert-manager.
 Please follow the documentation at
 [cert-manager.io](https://cert-manager.io/docs/usage/approver-policy/) for
 installing and using approver-policy.
+
+
+## Release Process
+
+Create a Git tag with a tagname that has a `v` prefix and push it to GitHub.
+This will trigger the [release workflow].
+
+1. Create and push a Git tag
+
+```sh
+export VERSION=v0.5.0-alpha.0
+git tag --annotate --message="Release ${VERSION}" "${VERSION}"
+git push origin "${VERSION}"
+```
+
+2. Wait for the [release workflow] to succeed.
+
+3. Visit the [releases page], edit the draft release, click "Generate release notes", and publish the release.
+
+[release workflow]: https://github.com/cert-manager/approver-policy/actions/workflows/release.yaml
+[releases page]: https://github.com/cert-manager/approver-policy/releases


### PR DESCRIPTION
I'd like to merge this into the in-repo automated-releases branch so that I can test the GitHub action with Quay.io credentials which are stored in GitHub secrets in the approver-policy repo.

I tested this using my fork of this repo and using a temporary Docker repository:
 * https://github.com/wallrj/approver-policy/actions/runs/3438472780
 * https://github.com/wallrj/approver-policy/releases/tag/v0.5.0-alpha.0

![image](https://user-images.githubusercontent.com/978965/201163517-3e8f1740-85bd-4ec0-9965-0ba875032160.png)


I'm satisfied that this works. And now I'll merge this into the approver-policy in-repo branch so that I can test it there.