### PR TITLE
Partially automate the Helm chart release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,9 @@ jobs:
     needs:
       - docker-image
     steps:
+      - uses: actions/checkout@v3
+      - id: create_helm_archive
+        run: make helm-archive
       - id: create_release
         uses: actions/create-release@v1
         env:
@@ -47,3 +50,11 @@ jobs:
           prerelease: true
           body: |
             Docker Image: `${{ env.IMAGE }}`
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.create_helm_archive.outputs.path }}
+          asset_name: cert-manager-approver-policy.helm-chart.tgz
+          asset_content_type: application/gzip

--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,8 @@ $(BINDIR)/ginkgo:
 $(BINDIR)/kind:
 	cd hack/tools && go build -o $(BINDIR)/kind sigs.k8s.io/kind
 
-$(BINDIR)/helm:
-	curl -o $(BINDIR)/helm.tar.gz -LO "https://get.helm.sh/helm-v$(HELM_VERSION)-$(OS)-$(ARCH).tar.gz"
+$(BINDIR)/helm: | $(BINDIR)
+	curl -o $(BINDIR)/helm.tar.gz -sSL "https://get.helm.sh/helm-v$(HELM_VERSION)-$(OS)-$(ARCH).tar.gz"
 	tar -C $(BINDIR) -xzf $(BINDIR)/helm.tar.gz
 	cp $(BINDIR)/$(OS)-$(ARCH)/helm $(BINDIR)/helm
 	rm -r $(BINDIR)/$(OS)-$(ARCH) $(BINDIR)/helm.tar.gz

--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ installing and using approver-policy.
 
 ## Release Process
 
-Create a Git tag with a tagname that has a `v` prefix and push it to GitHub.
-This will trigger the [release workflow].
+There is a semi-automated release process for approver-policy.
+When you create a Git tag with a tagname that has a `v` prefix and push it to GitHub.
+it will trigger the [release workflow].
+This will create and push a Docker image to `quay.io/jetstack/cert-manager-approver-policy:${{ github.ref_name }}`,
+create a Helm chart file,
+and finally create *draft* GitHub release with the Helm chart file attached and containing a reference to the Docker image.
 
 1. Create and push a Git tag
 
@@ -37,9 +41,14 @@ git tag --annotate --message="Release ${VERSION}" "${VERSION}"
 git push origin "${VERSION}"
 ```
 
-2. Wait for the [release workflow] to succeed.
+2. Wait for the [release workflow] to succeed and if successful,
+   visit the draft release page to download the attached Helm chart attachment.
 
-3. Visit the [releases page], edit the draft release, click "Generate release notes", and publish the release.
+3. Create a PR in the [jetstack/jetstack-charts repository on GitHub](https://github.com/jetstack/jetstack-charts),
+   containing the Helm chart file that is attached to the draft GitHub release.
+   Wait for it to be merged and verify that the Helm chart is available from https://charts.jetstack.io.
+
+4. Visit the [releases page], edit the draft release, click "Generate release notes", and publish the release.
 
 [release workflow]: https://github.com/cert-manager/approver-policy/actions/workflows/release.yaml
 [releases page]: https://github.com/cert-manager/approver-policy/releases

--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -36,7 +36,7 @@ A Helm chart for cert-manager-approver-policy
 | app.webhook.timeoutSeconds | int | `5` | Timeout of webhook HTTP request. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-approver-policy"` | Target image repository. |
-| image.tag | string | `"v0.4.0"` | Target image version tag. |
+| image.tag | string | `""` | Target image version tag (if empty, Chart AppVersion will be used) |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the approver-policy container image. |
 | replicaCount | int | `1` | Number of replicas of approver-policy to run. |
 | resources | object | `{}` |  |

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: {{ include "cert-manager-approver-policy.name" . }}
       containers:
       - name: {{ include "cert-manager-approver-policy.name" . }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.app.webhook.port }}

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -4,8 +4,8 @@ replicaCount: 1
 image:
   # -- Target image repository.
   repository: quay.io/jetstack/cert-manager-approver-policy
-  # -- Target image version tag.
-  tag: v0.4.0
+  # -- Target image version tag (if empty, Chart AppVersion will be used)
+  tag: ""
   # -- Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
I've added a `make helm-archive` target and call that in the GitHub release action and attach the Helm chart file to the draft release.
(I've temporarily reduced the number of architectures in the Docker image, so that can test and iterate on the release process)

Test Release: 
 * https://github.com/wallrj/approver-policy/actions/runs/3470846645
 * https://github.com/wallrj/approver-policy/releases/tag/v0.5.0-alpha.1