### PR TITLE
Update distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN make build VERSION=${VERSION}
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static@sha256:bca3c203cdb36f5914ab8568e4c25165643ea9b711b41a8a58b42c80a51ed609
+FROM gcr.io/distroless/static@sha256:5759d194607e472ff80fff5833442d3991dd89b219c96552837a2c8f74058617
 LABEL description="cert-manager Approver based on CertificateRequestPolicy CRD policies"
 
 WORKDIR /


### PR DESCRIPTION
I ran  the following command to get the latest base image checksum:

```terminal
$ crane digest gcr.io/distroless/static:latest
sha256:5759d194607e472ff80fff5833442d3991dd89b219c96552837a2c8f74058617
```


The OCI object with that digest is a multi-arch Docker image

```terminal
$ crane manifest gcr.io/distroless/static@sha256:5759d194607e472ff80fff5833442d3991dd89b219c96552837a2c8f74058617
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 426,
         "digest": "sha256:ebd8cc37d22551dce0957ba8e58f03b22a8448bbf844c8c9ded4feef883b36bc",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 426,
         "digest": "sha256:f0bc64e50983fb4ca0d325f330651c1970cf05a7c8fdebaef86330097c5da10f",
         "platform": {
            "architecture": "arm",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 426,
         "digest": "sha256:b85ecc2cf83157d054f1c358eda78408352cd0e320ae0ed9055f9af0f4f8eaa8",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 426,
         "digest": "sha256:982801c3f71c777f134cc4398f011283c692d4a0c29901671fdb660626ba937b",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 426,
         "digest": "sha256:1dd0a37cb6556b320f252af2f8fa0463ba00557d42a93c99ac5e1dd21cbc1daa",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```

So the [build-push-action](https://github.com/docker/build-push-action) that we use in the release workflow should be able to use the latest arch specific base image for each of the architectures that we include in the approver-policy multi-arch image: