### PR TITLE
Add explicit namespaces to all namespaced resources in Helm charts

### DIFF
--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cert-manager-approver-policy.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "cert-manager-approver-policy.labels" . | indent 4 }}
 spec:

--- a/deploy/charts/approver-policy/templates/metrics-service.yaml
+++ b/deploy/charts/approver-policy/templates/metrics-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cert-manager-approver-policy.name" . }}-metrics
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "cert-manager-approver-policy.name" . }}
 {{ include "cert-manager-approver-policy.labels" . | indent 4 }}

--- a/deploy/charts/approver-policy/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/approver-policy/templates/metrics-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "cert-manager-approver-policy.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "cert-manager-approver-policy.name" . }}
 {{ include "cert-manager-approver-policy.labels" . | indent 4 }}

--- a/deploy/charts/approver-policy/templates/role.yaml
+++ b/deploy/charts/approver-policy/templates/role.yaml
@@ -2,6 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "cert-manager-approver-policy.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "cert-manager-approver-policy.labels" . | indent 4 }}
 rules:

--- a/deploy/charts/approver-policy/templates/rolebinding.yaml
+++ b/deploy/charts/approver-policy/templates/rolebinding.yaml
@@ -2,6 +2,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "cert-manager-approver-policy.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "cert-manager-approver-policy.labels" . | indent 4 }}
 roleRef:

--- a/deploy/charts/approver-policy/templates/serviceaccount.yaml
+++ b/deploy/charts/approver-policy/templates/serviceaccount.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "cert-manager-approver-policy.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{ include "cert-manager-approver-policy.labels" . | indent 4 }}

--- a/deploy/charts/approver-policy/templates/webhook.yaml
+++ b/deploy/charts/approver-policy/templates/webhook.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cert-manager-approver-policy.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "cert-manager-approver-policy.name" . }}
 {{ include "cert-manager-approver-policy.labels" . | indent 4 }}
@@ -54,6 +55,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "cert-manager-approver-policy.name" . }}-tls
+  namespace: {{ .Release.Namespace | quote }}
   annotations:
     cert-manager.io/allow-direct-injection: "true"
   labels:


### PR DESCRIPTION
This helps with templating, after running `helm template -n test ...` the namespaces are also included in the manifest.
This prevents the user from running `kubectl apply -n not-test -f rendered.yaml`. This is important because of references that still point to the `test` namespace.