### PR TITLE
Remove leader election in integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,7 @@ bin
 *.swo
 *~
 
+.vscode
+
 /approver-policy
 /_artifacts

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ helm-docs: $(BINDIR)/helm-docs # verify helm-docs
 
 .PHONY: test
 test: depend lint vet ## test approver-policy
-	KUBEBUILDER_ASSETS=$(BINDIR)/kubebuilder/bin ROOTDIR=$(CURDIR) go test -v $(TEST_ARGS) ./cmd/... ./pkg/...
+	KUBEBUILDER_ASSETS=$(BINDIR)/kubebuilder/bin ROOTDIR=$(CURDIR) $(BINDIR)/ginkgo -procs=1 -v $(TEST_ARGS) ./cmd/... ./pkg/...
 
 .PHONY: build
 build: $(BINDIR) ## Build manager binary.


### PR DESCRIPTION
We can enforce tests to be run one after another without using leader election (setting procs=1 in ginkgo).
This PR also adds a check in code to make sure no two integration tests are running at the same time.
This removes the large amount of console messages related to leader election.