### PR TITLE
Fixes a typo

### DIFF
--- a/docs/examples/all-options.yaml
+++ b/docs/examples/all-options.yaml
@@ -73,12 +73,12 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cert-manager-policy:example-com
+  name: cert-manager-policy:all-options
   namespace: sandbox
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: cert-manager-policy:example-com
+  name: cert-manager-policy:all-options
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User


### PR DESCRIPTION
example RBAC created for a `CertificateRequestPolicy` named 'all-options' was referring to `CertificateRequestPolicy` named 'example-com'.