### PR TITLE
Templating in policy

### DIFF
--- a/pkg/internal/approver/allowed/evaluator.go
+++ b/pkg/internal/approver/allowed/evaluator.go
@@ -55,10 +55,12 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 		return approver.EvaluationResponse{}, err
 	}
 
+	td := util.TemplateData{Request: request}
+
 	if len(csr.Subject.CommonName) > 0 {
 		if allowed.CommonName == nil || allowed.CommonName.Value == nil {
 			el = append(el, field.Invalid(fldPath.Child("commonName", "value"), csr.Subject.CommonName, "nil"))
-		} else if !util.WildcardMatches(*allowed.CommonName.Value, csr.Subject.CommonName) {
+		} else if !util.WildcardMatches(util.TemplateStr(td, *allowed.CommonName.Value), csr.Subject.CommonName) {
 			el = append(el, field.Invalid(fldPath.Child("commonName", "value"), csr.Subject.CommonName, *allowed.CommonName.Value))
 		}
 	} else if allowed.CommonName != nil && allowed.CommonName.Required != nil && *allowed.CommonName.Required {
@@ -68,7 +70,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.DNSNames) > 0 {
 		if allowed.DNSNames == nil || allowed.DNSNames.Values == nil {
 			el = append(el, field.Invalid(fldPath.Child("dnsNames", "values"), csr.DNSNames, "nil"))
-		} else if !util.WildcardSubset(*allowed.DNSNames.Values, csr.DNSNames) {
+		} else if !util.WildcardSubset(util.TemplateArray(td, *allowed.DNSNames.Values), csr.DNSNames) {
 			el = append(el, field.Invalid(fldPath.Child("dnsNames", "values"), csr.DNSNames, strings.Join(*allowed.DNSNames.Values, ", ")))
 		}
 	} else if allowed.DNSNames != nil && allowed.DNSNames.Required != nil && *allowed.DNSNames.Required {
@@ -82,7 +84,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 		}
 		if allowed.IPAddresses == nil || allowed.IPAddresses.Values == nil {
 			el = append(el, field.Invalid(fldPath.Child("ipAddresses", "values"), ips, "nil"))
-		} else if !util.WildcardSubset(*allowed.IPAddresses.Values, ips) {
+		} else if !util.WildcardSubset(util.TemplateArray(td, *allowed.IPAddresses.Values), ips) {
 			el = append(el, field.Invalid(fldPath.Child("ipAddresses", "values"), ips, strings.Join(*allowed.IPAddresses.Values, ", ")))
 		}
 	} else if allowed.IPAddresses != nil && allowed.IPAddresses.Required != nil && *allowed.IPAddresses.Required {
@@ -96,7 +98,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 		}
 		if allowed.URIs == nil || allowed.URIs.Values == nil {
 			el = append(el, field.Invalid(fldPath.Child("uris", "values"), uris, "nil"))
-		} else if !util.WildcardSubset(*allowed.URIs.Values, uris) {
+		} else if !util.WildcardSubset(util.TemplateArray(td, *allowed.URIs.Values), uris) {
 			el = append(el, field.Invalid(fldPath.Child("uris", "values"), uris, strings.Join(*allowed.URIs.Values, ", ")))
 		}
 	} else if allowed.URIs != nil && allowed.URIs.Required != nil && *allowed.URIs.Required {
@@ -106,7 +108,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.EmailAddresses) > 0 {
 		if allowed.EmailAddresses == nil || allowed.EmailAddresses.Values == nil {
 			el = append(el, field.Invalid(fldPath.Child("emailAddresses", "values"), csr.EmailAddresses, "nil"))
-		} else if !util.WildcardSubset(*allowed.EmailAddresses.Values, csr.EmailAddresses) {
+		} else if !util.WildcardSubset(util.TemplateArray(td, *allowed.EmailAddresses.Values), csr.EmailAddresses) {
 			el = append(el, field.Invalid(fldPath.Child("emailAddresses", "values"), csr.EmailAddresses, strings.Join(*allowed.EmailAddresses.Values, ", ")))
 		}
 	} else if allowed.EmailAddresses != nil && allowed.EmailAddresses.Required != nil && *allowed.EmailAddresses.Required {
@@ -145,7 +147,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.Subject.Organization) > 0 {
 		if allowedSub == nil || allowedSub.Organizations == nil || allowedSub.Organizations.Values == nil {
 			el = append(el, field.Invalid(fldPath.Child("organizations", "values"), csr.Subject.Organization, "nil"))
-		} else if !util.WildcardSubset(*allowedSub.Organizations.Values, csr.Subject.Organization) {
+		} else if !util.WildcardSubset(util.TemplateArray(td, *allowedSub.Organizations.Values), csr.Subject.Organization) {
 			el = append(el, field.Invalid(fldPath.Child("organizations", "values"), csr.Subject.Organization, strings.Join(*allowedSub.Organizations.Values, ", ")))
 		}
 	} else if allowedSub != nil && allowedSub.Organizations != nil && allowedSub.Organizations.Required != nil && *allowedSub.Organizations.Required {
@@ -155,7 +157,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.Subject.Country) > 0 {
 		if allowedSub == nil || allowedSub.Countries == nil {
 			el = append(el, field.Invalid(fldPath.Child("countries", "values"), csr.Subject.Country, "nil"))
-		} else if !util.WildcardSubset(*allowedSub.Countries.Values, csr.Subject.Country) {
+		} else if !util.WildcardSubset(util.TemplateArray(td, *allowedSub.Countries.Values), csr.Subject.Country) {
 			el = append(el, field.Invalid(fldPath.Child("countries", "values"), csr.Subject.Country, strings.Join(*allowedSub.Countries.Values, ", ")))
 		}
 	} else if allowedSub != nil && allowedSub.Countries != nil && allowedSub.Countries.Required != nil && *allowedSub.Countries.Required {
@@ -165,7 +167,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.Subject.OrganizationalUnit) > 0 {
 		if allowedSub == nil || allowedSub.OrganizationalUnits == nil {
 			el = append(el, field.Invalid(fldPath.Child("organizationalUnits", "values"), csr.Subject.OrganizationalUnit, "nil"))
-		} else if !util.WildcardSubset(*allowedSub.OrganizationalUnits.Values, csr.Subject.OrganizationalUnit) {
+		} else if !util.WildcardSubset(util.TemplateArray(td, *allowedSub.OrganizationalUnits.Values), csr.Subject.OrganizationalUnit) {
 			el = append(el, field.Invalid(fldPath.Child("organizationalUnits", "values"), csr.Subject.OrganizationalUnit, strings.Join(*allowedSub.OrganizationalUnits.Values, ", ")))
 		}
 	} else if allowedSub != nil && allowedSub.OrganizationalUnits != nil && allowedSub.OrganizationalUnits.Required != nil && *allowedSub.OrganizationalUnits.Required {
@@ -175,7 +177,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.Subject.Locality) > 0 {
 		if allowedSub == nil || allowedSub.Localities == nil {
 			el = append(el, field.Invalid(fldPath.Child("localities", "values"), csr.Subject.Locality, "nil"))
-		} else if !util.WildcardSubset(*allowedSub.Localities.Values, csr.Subject.Locality) {
+		} else if !util.WildcardSubset(util.TemplateArray(td, *allowedSub.Localities.Values), csr.Subject.Locality) {
 			el = append(el, field.Invalid(fldPath.Child("localities", "values"), csr.Subject.Locality, strings.Join(*allowedSub.Localities.Values, ", ")))
 		}
 	} else if allowedSub != nil && allowedSub.Localities != nil && allowedSub.Localities.Required != nil && *allowedSub.Localities.Required {
@@ -185,7 +187,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.Subject.Province) > 0 {
 		if allowedSub == nil || allowedSub.Provinces == nil {
 			el = append(el, field.Invalid(fldPath.Child("provinces", "values"), csr.Subject.Province, "nil"))
-		} else if !util.WildcardSubset(*allowedSub.Provinces.Values, csr.Subject.Province) {
+		} else if !util.WildcardSubset(util.TemplateArray(td, *allowedSub.Provinces.Values), csr.Subject.Province) {
 			el = append(el, field.Invalid(fldPath.Child("provinces", "values"), csr.Subject.Province, strings.Join(*allowedSub.Provinces.Values, ", ")))
 		}
 	} else if allowedSub != nil && allowedSub.Provinces != nil && allowedSub.Provinces.Required != nil && *allowedSub.Provinces.Required {
@@ -195,7 +197,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.Subject.StreetAddress) > 0 {
 		if allowedSub == nil || allowedSub.StreetAddresses == nil {
 			el = append(el, field.Invalid(fldPath.Child("streetAddresses", "values"), csr.Subject.StreetAddress, "nil"))
-		} else if !util.WildcardSubset(*allowedSub.StreetAddresses.Values, csr.Subject.StreetAddress) {
+		} else if !util.WildcardSubset(util.TemplateArray(td, *allowedSub.StreetAddresses.Values), csr.Subject.StreetAddress) {
 			el = append(el, field.Invalid(fldPath.Child("streetAddresses", "values"), csr.Subject.StreetAddress, strings.Join(*allowedSub.StreetAddresses.Values, ", ")))
 		}
 	} else if allowedSub != nil && allowedSub.StreetAddresses != nil && allowedSub.StreetAddresses.Required != nil && *allowedSub.StreetAddresses.Required {
@@ -205,7 +207,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.Subject.PostalCode) > 0 {
 		if allowedSub == nil || allowedSub.PostalCodes == nil {
 			el = append(el, field.Invalid(fldPath.Child("postalCodes", "values"), csr.Subject.PostalCode, "nil"))
-		} else if !util.WildcardSubset(*allowedSub.PostalCodes.Values, csr.Subject.PostalCode) {
+		} else if !util.WildcardSubset(util.TemplateArray(td, *allowedSub.PostalCodes.Values), csr.Subject.PostalCode) {
 			el = append(el, field.Invalid(fldPath.Child("postalCodes", "values"), csr.Subject.PostalCode, strings.Join(*allowedSub.PostalCodes.Values, ", ")))
 		}
 	} else if allowedSub != nil && allowedSub.PostalCodes != nil && allowedSub.PostalCodes.Required != nil && *allowedSub.PostalCodes.Required {
@@ -215,7 +217,7 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	if len(csr.Subject.SerialNumber) > 0 {
 		if allowedSub == nil || allowedSub.SerialNumber == nil {
 			el = append(el, field.Invalid(fldPath.Child("serialNumber", "value"), csr.Subject.SerialNumber, "nil"))
-		} else if !util.WildcardMatches(*allowedSub.SerialNumber.Value, csr.Subject.SerialNumber) {
+		} else if !util.WildcardMatches(util.TemplateStr(td, *allowedSub.SerialNumber.Value), csr.Subject.SerialNumber) {
 			el = append(el, field.Invalid(fldPath.Child("serialNumber", "value"), csr.Subject.SerialNumber, *allowedSub.SerialNumber.Value))
 		}
 	} else if allowedSub != nil && allowedSub.SerialNumber != nil && allowedSub.SerialNumber.Required != nil && *allowedSub.SerialNumber.Required {

--- a/pkg/internal/util/template.go
+++ b/pkg/internal/util/template.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"text/template"
+)
+
+// TemplateData is the data we will be able to retrieve data from.
+// It just contains the request but could be enriched later.
+type TemplateData struct {
+	Request *cmapi.CertificateRequest
+}
+
+// TemplateStr takes an input string which may be a template and replaces
+// appropriate templates with data.
+func TemplateStr(data TemplateData, input string) string {
+
+	t, err := template.New("template").Parse(input)
+	if err != nil {
+		return input
+	}
+
+	buffer := new(bytes.Buffer)
+	err = t.Execute(buffer, data)
+	if err != nil {
+		return input
+	}
+
+	return buffer.String()
+}
+
+// TemplateArray takes an input string array which may be a template and replaces
+// appropriate templates with data.
+func TemplateArray(data TemplateData, inputs []string) []string {
+	var results = make([]string, 0)
+
+	for _, input := range inputs {
+		results = append(results, TemplateStr(data, input))
+	}
+
+	return results
+}

--- a/pkg/internal/util/template_test.go
+++ b/pkg/internal/util/template_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestTemplateStr(t *testing.T) {
+
+	// Prepare a certificate request with values
+	request := cmapi.CertificateRequest{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "request-ns"},
+		Spec:       cmapi.CertificateRequestSpec{},
+		Status:     cmapi.CertificateRequestStatus{},
+	}
+
+	// Create the tests
+	tests := []struct {
+		testname string
+		data     TemplateData
+		input    string
+		exp      string
+	}{
+		{
+			testname: "No template",
+			data:     TemplateData{Request: &request},
+			input:    "not templated",
+			exp:      "not templated",
+		},
+		{
+			testname: "namespace template",
+			data:     TemplateData{Request: &request},
+			input:    "---{{ .Request.Namespace }}---",
+			exp:      "---request-ns---",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s", test.input), func(t *testing.T) {
+			if match := TemplateStr(test.data, test.input); match != test.exp {
+				t.Errorf("unexpected result (%s): exp=\"%s\" got=\"%s\"",
+					test.input, test.exp, match)
+			}
+		})
+	}
+}
+
+func TestTemplateArray(t *testing.T) {
+
+	// Prepare a certificate request with values
+	request := cmapi.CertificateRequest{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "request-ns"},
+		Spec:       cmapi.CertificateRequestSpec{},
+		Status:     cmapi.CertificateRequestStatus{},
+	}
+
+	// Create the tests
+	tests := []struct {
+		testname string
+		data     TemplateData
+		inputs   []string
+		exps     []string
+	}{
+		{
+			testname: "No template",
+			data:     TemplateData{Request: &request},
+			inputs:   []string{"not templated 1", "not templated 2"},
+			exps:     []string{"not templated 1", "not templated 2"},
+		},
+		{
+			testname: "namespace template",
+			data:     TemplateData{Request: &request},
+			inputs:   []string{"ns: '{{ .Request.Namespace }}'"},
+			exps:     []string{"ns: 'request-ns'"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s", test.inputs), func(t *testing.T) {
+			results := TemplateArray(test.data, test.inputs)
+			if len(results) != len(test.exps) {
+				t.Errorf("unexpected length of arrays. exp=%d got %d",
+					len(test.exps), len(results))
+			}
+			for idx := range results {
+				if idx > len(test.exps) {
+					// Failsafe for different array lengths
+					continue
+				}
+
+				if results[idx] != test.exps[idx] {
+					t.Errorf("unexpected result (%s): exp=\"%s\" got=\"%s\"",
+						test.inputs[idx], test.exps[idx], results[idx])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR enables using templating in Policy with data from the request when validating the request.

One use case would be to allow dnsNames with the pattern "*.{{ .Request.Namespace }}.svc" but there are certainly other use cases.

This PR does not yet include any documentation (only comments in code) but if you agree this is a good idea, I'll add some as well.

Closes #62 