### PR TITLE
Fix Helm chart volume mount indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,11 @@ verify-pod-security-standards: $(helm_chart_archive) | $(BINDIR)/kyverno $(BINDI
 	$(BINDIR)/kyverno apply <($(BINDIR)/kustomize build https://github.com/kyverno/policies/pod-security/enforce) \
 		--resource <($(BINDIR)/helm template $(helm_chart_archive)) 2>/dev/null
 
+# Run both `helm lint` and `helm template`, to check that the templates can be rendered.
 .PHONY: verify-helm-lint
 verify-helm-lint: $(helm_chart_archive) | $(BINDIR)/helm
 	$(BINDIR)/helm lint $(helm_chart_archive)
+	$(BINDIR)/helm template $(helm_chart_archive) --values hack/helm/sample-chart-values.yaml
 
 # instead of running verify-generate-api-docs, this target uses the gomarkdoc --check flag to verify that the docs are up to date
 .PHONY: verify-api-docs

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
 
         volumeMounts:
         {{- with .Values.volumeMounts }}
-        {{- toYaml . | nindent 10 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         - mountPath: /tmp
           name: temp-dir

--- a/hack/helm/sample-chart-values.yaml
+++ b/hack/helm/sample-chart-values.yaml
@@ -1,0 +1,15 @@
+# An example values file, which will be used when linting the Helm chart, to
+# verify that the templates can be rendered.
+# See make verify-helm-lint
+#
+# Volumes and volume mounts can be overridden
+volumeMounts:
+  - name: ca-cert-example-volume
+    mountPath: "/etc/ssl/certs/ca-cert-example-ca.crt"
+    subPath: ca.crt
+    readOnly: true
+volumes:
+  - name: ca-cert-example-volume
+    configMap:
+      name: ca-cert-example
+      optional: false


### PR DESCRIPTION
Fixes: #213 

* Added a test to verify that Helm charts can be rendered
  And that values which are expected to be overridden, do not cause rendering errors.
  For example: https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_approver-policy/214/pull-cert-manager-approver-policy-verify/1636784667623428096#1:build-log.txt%3A165-171