### PR TITLE
feat: fix app label of metrics svc for ServiceMonitor discovery

### DIFF
--- a/deploy/charts/approver-policy/templates/metrics-service.yaml
+++ b/deploy/charts/approver-policy/templates/metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "cert-manager-approver-policy.name" . }}-metrics
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app: {{ include "cert-manager-approver-policy.name" . }}
+    app: {{ include "cert-manager-approver-policy.name" . }}-metrics
 {{ include "cert-manager-approver-policy.labels" . | indent 4 }}
 spec:
   type: {{ .Values.app.metrics.service.type }}

--- a/deploy/charts/approver-policy/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/approver-policy/templates/metrics-servicemonitor.yaml
@@ -15,7 +15,7 @@ spec:
   jobLabel: {{ include "cert-manager-approver-policy.name" . }}
   selector:
     matchLabels:
-      app: {{ include "cert-manager-approver-policy.name" . }}
+      app: {{ include "cert-manager-approver-policy.name" . }}-metrics
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
The ServiceMonitor targets both the web hook service and the metrics service. Yet, only the metrics service must be scraped (the probe could be scraped too via the blackbox-exporter, but that is a subject for another PR). The webhook service must not be discovered by Prometheus.

### Prerequisites
Having a Kubernetes cluster running with the cert-manager/approver-policy chart installed and a prometheus instance ready to scrape metrics.

### How to reproduce

1. Make your Prometheus instance is scrape your approver-policy metrics. For this purpose, set the following values:
```yaml
nameOverride: cert-manager-approver-policy

app:
  metrics:
    port: 9402
    service:
      enabled: true
      servicemonitor:
        enabled: true
```

2. Open the Prometheus UI, you should see something similar:

![Screenshot_2023-04-28_at_06_11_51-3-2](https://user-images.githubusercontent.com/97767501/235061328-04c15956-ae6a-4a7b-967f-785de5e763f8.png)

I have 2 replicas, hence the (4/4 up) in the target, but the point is that for a given replica, there is currently 2 services scraped: the webhook Service and the metrics Service. The metrics service should obviously be scraped, but not the webhook service (not even listening on port `9402` but on port `443`) as it is not serving any metrics. 

That is happening because the [ServiceMonitor here](https://github.com/cert-manager/approver-policy/blob/main/deploy/charts/approver-policy/templates/metrics-servicemonitor.yaml#L18) is scraping on the following app label:

```yaml
spec:
  selector:
    matchLabels:
      app: {{ include "cert-manager-approver-policy.name" . }}
```

Yet, both the metrics Service and the webhook Service have this label, check [here](https://github.com/cert-manager/approver-policy/blob/main/deploy/charts/approver-policy/templates/metrics-service.yaml#L8) and [here](https://github.com/cert-manager/approver-policy/blob/main/deploy/charts/approver-policy/templates/webhook.yaml#L7).

### How to test

By changing the `app` label of the metrics Service and setting the ServiceMonitor to select the new same `app` label, only the metrics Service gets scraped and you should see the following in your Prometheus UI (2/2 up) for 2 replicas:

![Screenshot_2023-04-28_at_06_48_13](https://user-images.githubusercontent.com/97767501/235065290-1bd0da90-e165-40f6-b154-4c3bb713a5f9.png)

Simply apply the following JSON Patches to your chart installed in namespace `cert-manager` (I am using Helmfile so this is Helmfile syntax, but any tool applying the following JSON Patches obviously works):

```yaml
jsonPatches:
  # The ServiceMonitor currently targets both the metrics endpoint and the webhook endpoint
  - target:
      group: ""
      version: v1
      kind: Service
      name: cert-manager-approver-policy-metrics
      namespace: cert-manager
    patch:
      - op: replace
        path: "/metadata/labels/app"
        value: cert-manager-approver-policy-metrics
  - target:
      group: monitoring.coreos.com
      version: v1
      kind: ServiceMonitor
      name: cert-manager-approver-policy
      namespace: cert-manager
    patch:
      - op: replace
        path: "/spec/selector/matchLabels/app"
        value: cert-manager-approver-policy-metrics
```