### PR TITLE
Remove the command field from the yaml deployment

### DIFF
--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -42,7 +42,6 @@ spec:
             path: "/readyz"
           initialDelaySeconds: 3
           periodSeconds: 7
-        command: ["cert-manager-approver-policy"]
         args:
           - --log-level={{.Values.app.logLevel}}
 


### PR DESCRIPTION
This PR makes it easier to swap the image with an image with another entrypoint (eg. because you are running approver-policy with additional plugins)