### PR TITLE
Fix uninitialized controller-runtime logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so
 *.dylib
 _bin
+bin
 
 # Test binary, build with `go test -c`
 *.test
@@ -19,6 +20,7 @@ _bin
 
 # editor and IDE paraphernalia
 .idea
+*.iml
 *.swp
 *.swo
 *~

--- a/pkg/internal/cmd/cmd.go
+++ b/pkg/internal/cmd/cmd.go
@@ -50,6 +50,10 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			logf.Log = opts.Logr.WithName("apiutil")
 			log := opts.Logr.WithName("main")
 
+			mlog := opts.Logr.WithName("controller-manager")
+
+			ctrl.SetLogger(mlog)
+
 			mgr, err := ctrl.NewManager(opts.RestConfig, ctrl.Options{
 				Scheme:                        policyapi.GlobalScheme,
 				LeaderElection:                true,
@@ -63,7 +67,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				Port:                          opts.Webhook.Port,
 				Host:                          opts.Webhook.Host,
 				CertDir:                       opts.Webhook.CertDir,
-				Logger:                        opts.Logr.WithName("controller-manager"),
+				Logger:                        mlog,
 			})
 			if err != nil {
 				return fmt.Errorf("unable to create controller manager: %w", err)

--- a/pkg/internal/controllers/test/util.go
+++ b/pkg/internal/controllers/test/util.go
@@ -141,6 +141,8 @@ func startControllers(registry *registry.Registry) (context.Context, func(), cor
 	log, ctx := ktesting.NewTestContext(GinkgoT())
 	ctx, cancel := context.WithCancel(ctx)
 
+	ctrl.SetLogger(log)
+
 	namespace := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "test-policy-",


### PR DESCRIPTION
This PR adds initialization of logger implementation for deferred loggers in c/r to avoid printing stack-trace on startup.

Close https://github.com/cert-manager/approver-policy/issues/252