### PR TITLE
HELM: add options for configuring image

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -40,9 +40,11 @@ A Helm chart for cert-manager-approver-policy
 | app.webhook.timeoutSeconds | int | `5` | Timeout of webhook HTTP request. |
 | app.webhook.tolerations | list | `[]` | https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | commonLabels | object | `{}` | Optional allow custom labels to be placed on resources |
+| image.digest | string | `nil` | Target image digest. Will override any tag if set. for example: digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20 |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
+| image.registry | string | `nil` | Target image registry. Will be prepended to the target image repositry if set. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-approver-policy"` | Target image repository. |
-| image.tag | string | `""` | Target image version tag (if empty, Chart AppVersion will be used) |
+| image.tag | string | `nil` | Target image version tag. Defaults to the chart's appVersion. |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the approver-policy container image. |
 | podAnnotations | object | `{}` | Optional allow custom annotations to be placed on cert-manager-approver pod |
 | replicaCount | int | `1` | Number of replicas of approver-policy to run. |

--- a/deploy/charts/approver-policy/templates/_helpers.tpl
+++ b/deploy/charts/approver-policy/templates/_helpers.tpl
@@ -27,3 +27,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ toYaml .Values.commonLabels }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Util function for generating the image URL based on the provided options.
+IMPORTANT: This function is standarized across all charts in the cert-manager GH organization.
+Any changes to this function should also be made in cert-manager, trust-manager, approver-policy, ...
+See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linked PRs.
+*/}}
+{{- define "image" -}}
+{{- $defaultTag := index . 1 -}}
+{{- with index . 0 -}}
+{{- if .registry -}}{{ printf "%s/%s" .registry .repository }}{{- else -}}{{- .repository -}}{{- end -}}
+{{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" (default $defaultTag .tag) }}{{- end -}}
+{{- end }}
+{{- end }}

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       serviceAccountName: {{ include "cert-manager-approver-policy.name" . }}
       containers:
       - name: {{ include "cert-manager-approver-policy.name" . }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.app.webhook.port }}

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -4,8 +4,17 @@ replicaCount: 1
 image:
   # -- Target image repository.
   repository: quay.io/jetstack/cert-manager-approver-policy
-  # -- Target image version tag (if empty, Chart AppVersion will be used)
-  tag: ""
+  # -- Target image registry. Will be prepended to the target image repositry if set.
+  registry:
+
+  # -- Target image version tag. Defaults to the chart's appVersion.
+  tag:
+
+  # -- Target image digest. Will override any tag if set.
+  # for example:
+  # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+  digest:
+
   # -- Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
I'm standardising the image options across all our charts (https://github.com/cert-manager/cert-manager/issues/6329).