### PR TITLE
Enable grouping for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,13 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  groups:
+    all:
+      patterns: ["*"]
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: weekly
+  groups:
+    all:
+      patterns: ["*"]


### PR DESCRIPTION
This PR adds grouping options for dependabot, it will make dependabot create single grouped PRs to upgrade deps.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

see https://github.com/cert-manager/issuer-lib/pull/65 & https://github.com/cert-manager/issuer-lib/pull/67 for working example