### PR TITLE
chore: add .gitattributes to mark generated files

### DIFF
--- a/ .gitattributes
+++ b/ .gitattributes
@@ -1,0 +1,5 @@
+deploy/charts/approver-policy/templates/crds/* linguist-generated=true
+deploy/charts/approver-policy/README.md linguist-generated=true
+docs/api/api.md linguist-generated=true
+
+**/zz_generated.*.go linguist-generated=true


### PR DESCRIPTION
Adds an initial .gitattributes files to mark generated files in this repository, ref. https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

This should improve the PR review process, as marked-generated files will be collapsed by default in the GitHub review UI.

Thanks to @jsoref for suggesting this!