### PR TITLE
refactor: support for multiple errors on same field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/cert-manager/cert-manager v1.13.1
 	github.com/go-logr/logr v1.2.4
+	github.com/google/go-cmp v0.5.9
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.28.0
 	github.com/spf13/cobra v1.7.0
@@ -47,7 +48,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20230510103437-eeec1cb781c3 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect

--- a/pkg/internal/approver/allowed/evaluator_test.go
+++ b/pkg/internal/approver/allowed/evaluator_test.go
@@ -25,6 +25,7 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cert-manager/cert-manager/test/unit/gen"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/pointer"
@@ -336,7 +337,9 @@ func Test_Evaluate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			response, err := allowed{}.Evaluate(context.TODO(), &policyapi.CertificateRequestPolicy{Spec: test.policy}, test.request)
 			assert.Equal(t, test.expErr, err != nil, "%v", err)
-			assert.Equal(t, test.expResponse, response, "unexpected evaluation response")
+			if diff := cmp.Diff(response, test.expResponse); diff != "" {
+				t.Errorf("unexpected evaluation response (-want +got):\n%v", diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
While working on https://github.com/cert-manager/approver-policy/pull/277, I realized that I need to be able to support multiple errors when evaluating each field on certificaterequests.

This PR is a simple refactoring from using `*field.Error` to `field.ErrorList` as the return type from evaluation functions. Also a minor improvement to one of the tests that were failing because of a bug in the refactoring. Is was impossible to spot the exact error without it. 😄 

/cc @inteon 