### PR TITLE
Add erikgb to project reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -16,3 +16,4 @@ reviewers:
 - irbekrm
 - sgtcodfish
 - inteon
+- erikgb


### PR DESCRIPTION
Ref. the [cert-manager governance document](https://github.com/cert-manager/community/blob/main/GOVERNANCE.md#reviewer), I would like to apply for the reviewer role in approver-policy.

I have been following this project for a long time, and have created an experimental approver-policy plugin to convince the maintainers to add CEL support: https://github.com/erikgb/cel-approver-policy-plugin. I have prepared a design (https://github.com/cert-manager/approver-policy/pull/256) for this new CEL expression feature, which I consider approved, but not merged - since we want to wait to keep some flexibility in the upcoming implementation: https://github.com/cert-manager/approver-policy/pull/277.

I would classify https://github.com/cert-manager/approver-policy/pull/280 as a significant contribution. At least I spent a lot of time on it, and I think it was a major improvement to the API docs.

Sponsor: @inteon @SgtCoDFish 