### PR TITLE
refactor: prepare code for introducing CEL validations

### DIFF
--- a/pkg/internal/approver/allowed/allowed.go
+++ b/pkg/internal/approver/allowed/allowed.go
@@ -30,7 +30,7 @@ import (
 
 // Load the allowed approver.
 func init() {
-	registry.Shared.Store(allowed{})
+	registry.Shared.Store(Approver())
 }
 
 // Approver returns an instance on the allowed approver.

--- a/pkg/internal/approver/allowed/evaluator_test.go
+++ b/pkg/internal/approver/allowed/evaluator_test.go
@@ -335,7 +335,7 @@ func Test_Evaluate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			response, err := allowed{}.Evaluate(context.TODO(), &policyapi.CertificateRequestPolicy{Spec: test.policy}, test.request)
+			response, err := Approver().Evaluate(context.TODO(), &policyapi.CertificateRequestPolicy{Spec: test.policy}, test.request)
 			assert.Equal(t, test.expErr, err != nil, "%v", err)
 			if diff := cmp.Diff(response, test.expResponse); diff != "" {
 				t.Errorf("unexpected evaluation response (-want +got):\n%v", diff)

--- a/pkg/internal/approver/allowed/validation_test.go
+++ b/pkg/internal/approver/allowed/validation_test.go
@@ -143,7 +143,7 @@ func Test_Validate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			response, err := allowed{}.Validate(context.TODO(), test.policy)
+			response, err := Approver().Validate(context.TODO(), test.policy)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expResponse, response)
 		})

--- a/pkg/internal/approver/constraints/constraints.go
+++ b/pkg/internal/approver/constraints/constraints.go
@@ -30,7 +30,7 @@ import (
 
 // Load the constraints approver.
 func init() {
-	registry.Shared.Store(constraints{})
+	registry.Shared.Store(Approver())
 }
 
 // Approver returns an instance on the constraints approver.

--- a/pkg/internal/approver/constraints/evaluator_test.go
+++ b/pkg/internal/approver/constraints/evaluator_test.go
@@ -158,7 +158,7 @@ func Test_Evaluate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			response, err := constraints{}.Evaluate(context.TODO(), &policyapi.CertificateRequestPolicy{Spec: test.policy}, test.request)
+			response, err := Approver().Evaluate(context.TODO(), &policyapi.CertificateRequestPolicy{Spec: test.policy}, test.request)
 			assert.Equal(t, test.expErr, err != nil, "%v", err)
 			assert.Equal(t, test.expResponse, response, "unexpected evaluation response")
 		})

--- a/pkg/internal/approver/constraints/validation_test.go
+++ b/pkg/internal/approver/constraints/validation_test.go
@@ -121,7 +121,7 @@ func Test_Validate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			response, err := constraints{}.Validate(context.TODO(), test.policy)
+			response, err := Approver().Validate(context.TODO(), test.policy)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expResponse, response)
 		})


### PR DESCRIPTION
I am still waiting for reviews on https://github.com/cert-manager/approver-policy/pull/277, and I think one of the reasons is that it appears big (a lot of changes). I know the feeling, so here is a preparation PR with some required refactorings:

- Always use the constructor to create `allowed` - since I want to init the upcoming CEL expression cache in this constructor. I have done the same for `constraints` for consistency.
- Introduced an interface to move the basic eval functions to `allowed`. This is required to get transparent access to the CEL expression cache singleton.

/cc @inteon 