### PR TITLE
Don't use ROOTDIR environment variable in tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,8 @@ $(BINDIR)/cert-manager/crds.yaml: | $(BINDIR)
 .PHONY: test
 test: cert_manager_crds tools ## Test approver-policy
 	KUBEBUILDER_ASSETS=$(BINDIR)/kubebuilder/bin \
-	ROOTDIR=$(CURDIR) \
+	CERT_MANAGER_CRDS=$(CURDIR)/$(BINDIR)/cert-manager/crds.yaml \
+	APPROVER_POLICY_CRDS=$(CURDIR)/deploy/charts/approver-policy/templates/crds/policy.cert-manager.io_certificaterequestpolicies.yaml \
 		$(BINDIR)/ginkgo -procs=1 -v $(TEST_ARGS) ./cmd/... ./pkg/...
 
 .PHONY: demo

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ $(BINDIR)/cert-manager/crds.yaml: | $(BINDIR)
 .PHONY: test
 test: cert_manager_crds tools ## Test approver-policy
 	KUBEBUILDER_ASSETS=$(BINDIR)/kubebuilder/bin \
-	CERT_MANAGER_CRDS=$(CURDIR)/$(BINDIR)/cert-manager/crds.yaml \
+	CERT_MANAGER_CRDS=$(BINDIR)/cert-manager/crds.yaml \
 	APPROVER_POLICY_CRDS=$(CURDIR)/deploy/charts/approver-policy/templates/crds/policy.cert-manager.io_certificaterequestpolicies.yaml \
 		$(BINDIR)/ginkgo -procs=1 -v $(TEST_ARGS) ./cmd/... ./pkg/...
 

--- a/pkg/internal/approver/manager/predicate/predicate_test.go
+++ b/pkg/internal/approver/manager/predicate/predicate_test.go
@@ -33,7 +33,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	policyapi "github.com/cert-manager/approver-policy/pkg/apis/policy/v1alpha1"
-	"github.com/cert-manager/approver-policy/test/env"
+	testenv "github.com/cert-manager/approver-policy/test/env"
 )
 
 func Test_RBACBound(t *testing.T) {
@@ -42,9 +42,9 @@ func Test_RBACBound(t *testing.T) {
 		cancel()
 	})
 
-	env := env.RunControlPlane(t, ctx,
-		env.GetenvOrFail(t, "CERT_MANAGER_CRDS"),
-		env.GetenvOrFail(t, "APPROVER_POLICY_CRDS"),
+	env := testenv.RunControlPlane(t, ctx,
+		testenv.GetenvOrFail(t, "CERT_MANAGER_CRDS"),
+		testenv.GetenvOrFail(t, "APPROVER_POLICY_CRDS"),
 	)
 
 	const (

--- a/pkg/internal/approver/manager/predicate/predicate_test.go
+++ b/pkg/internal/approver/manager/predicate/predicate_test.go
@@ -18,7 +18,6 @@ package predicate
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -43,10 +42,9 @@ func Test_RBACBound(t *testing.T) {
 		cancel()
 	})
 
-	rootDir := env.RootDirOrSkip(t)
 	env := env.RunControlPlane(t, ctx,
-		filepath.Join(rootDir, "_bin/cert-manager"),
-		filepath.Join(rootDir, "deploy/charts/approver-policy/templates/crds"),
+		env.GetenvOrFail(t, "CERT_MANAGER_CRDS"),
+		env.GetenvOrFail(t, "APPROVER_POLICY_CRDS"),
 	)
 
 	const (

--- a/pkg/internal/approver/manager/review_test.go
+++ b/pkg/internal/approver/manager/review_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cert-manager/approver-policy/pkg/approver/fake"
 	"github.com/cert-manager/approver-policy/pkg/approver/manager"
 	"github.com/cert-manager/approver-policy/pkg/internal/approver/manager/predicate"
-	"github.com/cert-manager/approver-policy/test/env"
+	testenv "github.com/cert-manager/approver-policy/test/env"
 )
 
 func Test_Review(t *testing.T) {
@@ -40,9 +40,9 @@ func Test_Review(t *testing.T) {
 		cancel()
 	})
 
-	env := env.RunControlPlane(t, ctx,
-		env.GetenvOrFail(t, "CERT_MANAGER_CRDS"),
-		env.GetenvOrFail(t, "APPROVER_POLICY_CRDS"),
+	env := testenv.RunControlPlane(t, ctx,
+		testenv.GetenvOrFail(t, "CERT_MANAGER_CRDS"),
+		testenv.GetenvOrFail(t, "APPROVER_POLICY_CRDS"),
 	)
 
 	expNoEvaluation := func(t *testing.T) approver.Evaluator {

--- a/pkg/internal/approver/manager/review_test.go
+++ b/pkg/internal/approver/manager/review_test.go
@@ -19,7 +19,6 @@ package manager
 import (
 	"context"
 	"errors"
-	"path/filepath"
 	"testing"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -41,10 +40,9 @@ func Test_Review(t *testing.T) {
 		cancel()
 	})
 
-	rootDir := env.RootDirOrSkip(t)
 	env := env.RunControlPlane(t, ctx,
-		filepath.Join(rootDir, "_bin/cert-manager"),
-		filepath.Join(rootDir, "deploy/charts/approver-policy/templates/crds"),
+		env.GetenvOrFail(t, "CERT_MANAGER_CRDS"),
+		env.GetenvOrFail(t, "APPROVER_POLICY_CRDS"),
 	)
 
 	expNoEvaluation := func(t *testing.T) approver.Evaluator {

--- a/pkg/internal/controllers/test/controllers_test.go
+++ b/pkg/internal/controllers/test/controllers_test.go
@@ -18,7 +18,6 @@ package test
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	testenv "github.com/cert-manager/approver-policy/test/env"
@@ -32,11 +31,9 @@ func Test_Controllers(t *testing.T) {
 		cancel()
 	})
 
-	rootDir := testenv.RootDirOrSkip(t)
-
 	env = testenv.RunControlPlane(t, ctx,
-		filepath.Join(rootDir, "_bin/cert-manager"),
-		filepath.Join(rootDir, "deploy/charts/approver-policy/templates/crds"),
+		testenv.GetenvOrFail(t, "CERT_MANAGER_CRDS"),
+		testenv.GetenvOrFail(t, "APPROVER_POLICY_CRDS"),
 	)
 	testenv.RunSuite(t, "approver-policy-controllers", "../../../../_artifacts")
 }

--- a/test/env/util.go
+++ b/test/env/util.go
@@ -53,14 +53,14 @@ users:
 `
 )
 
-// RootDirOrSkip returns the ROOTDIR environment variable, or skips if the
+// GetenvOrFail returns the specified environment variable, or fails if the
 // variable is undefined or empty.
-func RootDirOrSkip(t *testing.T) string {
-	rootDir := os.Getenv("ROOTDIR")
-	if len(rootDir) == 0 {
-		t.Skip("WARNING: skipping test as 'ROOTDIR' is not defined")
+func GetenvOrFail(t *testing.T, name string) string {
+	value := os.Getenv(name)
+	if len(value) == 0 {
+		t.Errorf("FAIL: failing test as %q is not defined", name)
 	}
-	return rootDir
+	return value
 }
 
 // writeKubeconfig writes a Kubeconfig file using the Kubernetes REST config.


### PR DESCRIPTION
We don't want to code the relative paths for test assets in Go.
Instead, we should configure that in our Make files and pass them as separate environment variables to Go.