### PR TITLE
Add Helm option to not include CRD

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-deploy/charts/approver-policy/templates/crds/* linguist-generated=true
+deploy/charts/approver-policy/templates/crd-* linguist-generated=true
 deploy/charts/approver-policy/README.md linguist-generated=true
 docs/api/api.md linguist-generated=true
 

--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -39,6 +39,7 @@ A Helm chart for cert-manager-approver-policy
 | app.webhook.timeoutSeconds | int | `5` | Timeout of webhook HTTP request. |
 | app.webhook.tolerations | list | `[]` | https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | commonLabels | object | `{}` | Optional allow custom labels to be placed on resources |
+| crds.enabled | bool | `true` | Whether or not to install the crds. |
 | image.digest | string | `nil` | Target image digest. Will override any tag if set. for example: digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20 |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.registry | string | `nil` | Target image registry. Will be prepended to the target image repositry if set. |

--- a/deploy/charts/approver-policy/templates/crd-policy.cert-manager.io_certificaterequestpolicies.yaml
+++ b/deploy/charts/approver-policy/templates/crd-policy.cert-manager.io_certificaterequestpolicies.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.crds.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1041,3 +1042,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{ end }}

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -109,3 +109,6 @@ commonLabels: {}
 # -- Optional allow custom annotations to be placed on cert-manager-approver pod
 podAnnotations: {}
 
+crds:
+  # -- Whether or not to install the crds.
+  enabled: true


### PR DESCRIPTION
TLDR; Adds the option to not install the CRD as part of the Helm chart. The CRD must still be installed separately.

If you install the approver-policy Helm chart with the `crds.enabled: true` option, uninstalling the Helm chart will result in also uninstalling the CRDs. This will trigger the CRs to be garbage collected and deleted too.
To prevent uninstalling the CRDs when the Helm chart is uninstalled, the CRDs can be installed separately. With the change proposed in this PR, this can be done as follows:

```bash
$ helm template cert-manager-approver-policy jetstack/cert-manager-approver-policy | \
        yq e '. | select(.kind == "CustomResourceDefinition")' \
       > approver-policy-crds.yaml

$ kubectl apply --server-side -f approver-policy-crds.yaml

$ helm upgrade cert-manager-approver-policy jetstack/cert-manager-approver-policy \
        -i -n cert-manager \
        --wait \
        --set crds.enabled=false
```

See https://github.com/cert-manager/trust-manager/pull/102#issuecomment-1400131204 for the equivalent change in trust-manager.