### PR TITLE
Upload junit and coverage results to ARTIFACTS folder

### DIFF
--- a/make/test-smoke.mk
+++ b/make/test-smoke.mk
@@ -55,6 +55,8 @@ test-smoke-deps: install
 ## @category Testing
 test-smoke: test-smoke-deps | kind-cluster $(NEEDS_GINKGO)
 	$(GINKGO) \
+		--output-dir=$(ARTIFACTS) \
+		--junit-report=junit-go-e2e.xml \
 		./test/smoke/ \
 		-ldflags $(go_manager_ldflags) \
 		-- \

--- a/make/test-unit.mk
+++ b/make/test-unit.mk
@@ -21,12 +21,16 @@ $(approver_policy_crds): $(helm_chart_archive) | $(NEEDS_HELM) $(NEEDS_YQ) $(bin
 .PHONY: test-unit
 ## Unit tests
 ## @category Testing
-test-unit: | $(cert_manager_crds) $(approver_policy_crds) $(NEEDS_GINKGO) $(NEEDS_ETCD) $(NEEDS_KUBE-APISERVER) $(NEEDS_KUBECTL)
+test-unit: | $(cert_manager_crds) $(approver_policy_crds) $(NEEDS_GO) $(NEEDS_GINKGO) $(NEEDS_ETCD) $(NEEDS_KUBE-APISERVER) $(NEEDS_KUBECTL) $(ARTIFACTS)
 	CERT_MANAGER_CRDS=$(CURDIR)/$(cert_manager_crds) \
 	APPROVER_POLICY_CRDS=$(CURDIR)/$(approver_policy_crds) \
 	KUBEBUILDER_ASSETS=$(CURDIR)/$(bin_dir)/tools \
 	$(GINKGO) \
+		--output-dir=$(ARTIFACTS) \
+		--junit-report=junit-go-e2e.xml \
+		--cover \
+		--coverprofile=filtered.cov \
 		./cmd/... ./pkg/... \
-		-procs=1 \
-		-v \
 		-ldflags $(go_manager_ldflags)
+
+	$(GO) tool cover -html=$(ARTIFACTS)/filtered.cov -o=$(ARTIFACTS)/filtered.html

--- a/pkg/internal/controllers/test/controllers_test.go
+++ b/pkg/internal/controllers/test/controllers_test.go
@@ -21,11 +21,15 @@ import (
 	"testing"
 
 	testenv "github.com/cert-manager/approver-policy/test/env"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 // Test_Controllers runs the full suite of tests for the approver-policy
 // controllers.
 func Test_Controllers(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
 	ctx, cancel := context.WithCancel(context.TODO())
 	t.Cleanup(func() {
 		cancel()
@@ -35,5 +39,6 @@ func Test_Controllers(t *testing.T) {
 		testenv.GetenvOrFail(t, "CERT_MANAGER_CRDS"),
 		testenv.GetenvOrFail(t, "APPROVER_POLICY_CRDS"),
 	)
-	testenv.RunSuite(t, "approver-policy-controllers", "../../../../_artifacts")
+
+	ginkgo.RunSpecs(t, "approver-policy-controllers")
 }

--- a/test/env/env.go
+++ b/test/env/env.go
@@ -18,13 +18,10 @@ package env
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	webhooktesting "github.com/cert-manager/cert-manager/test/webhook"
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
 	extapi "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -60,19 +57,6 @@ type Environment struct {
 	// UserClient is a client that is authenticated as the user "me@example.com",
 	// groups ["group-1", "group-2"].
 	UserClient client.Client
-}
-
-// RunSuite runs a Ginkgo test suite, and writes the results to the artefacts
-// directory. The artifacts directory may be overridden with `ARTIFACTS`
-// environment variable.
-func RunSuite(t *testing.T, suiteName, artifactsDir string) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-
-	if path := os.Getenv("ARTIFACTS"); len(path) > 0 {
-		artifactsDir = path
-	}
-
-	ginkgo.RunSpecs(t, suiteName)
 }
 
 // RunControlPlane runs a local API server and makes it ready for running tests

--- a/test/smoke/smoke_test.go
+++ b/test/smoke/smoke_test.go
@@ -19,10 +19,13 @@ package smoke
 import (
 	"testing"
 
-	"github.com/cert-manager/approver-policy/test/env"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 // Test_Smoke runs the full suite of smoke tests against approver-policy
 func Test_Smoke(t *testing.T) {
-	env.RunSuite(t, "approver-policy-smoke", "../../_artifacts")
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	ginkgo.RunSpecs(t, "approver-policy-smoke")
 }


### PR DESCRIPTION
Output junit reports to a file in the ARTIFACTS folder, so the tests show as a beautiful list in prow.

Also uploads coverage profile for the unit tests.