### PR TITLE
Use helm-tool for chart README

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -18,36 +18,643 @@ A Helm chart for cert-manager-approver-policy
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| app.approveSignerNames | list | `["issuers.cert-manager.io/*","clusterissuers.cert-manager.io/*"]` | List if signer names that approver-policy will be given permission to approve and deny. CertificateRequests referencing these signer names can be processed by approver-policy. See: https://cert-manager.io/docs/concepts/certificaterequest/#approval |
-| app.extraArgs | list | `[]` | Extra CLI arguments that will be passed to the approver-policy process. |
-| app.logLevel | int | `1` | Verbosity of approver-policy logging. |
-| app.metrics.port | int | `9402` | Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'. |
-| app.metrics.service | object | `{"enabled":true,"servicemonitor":{"enabled":false,"interval":"10s","labels":{},"prometheusInstance":"default","scrapeTimeout":"5s"},"type":"ClusterIP"}` | Service to expose metrics endpoint. |
-| app.metrics.service.enabled | bool | `true` | Create a Service resource to expose metrics endpoint. |
-| app.metrics.service.servicemonitor | object | `{"enabled":false,"interval":"10s","labels":{},"prometheusInstance":"default","scrapeTimeout":"5s"}` | ServiceMonitor resource for this Service. |
-| app.metrics.service.type | string | `"ClusterIP"` | Service type to expose metrics. |
-| app.readinessProbe.port | int | `6060` | Container port to expose approver-policy HTTP readiness probe on default network interface. |
-| app.webhook.affinity | object | `{}` | https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity |
-| app.webhook.dnsPolicy | string | `"ClusterFirst"` | May need to be changed if hostNetwork: true |
-| app.webhook.host | string | `"0.0.0.0"` | Host that the webhook listens on. |
-| app.webhook.hostNetwork | bool | `false` | Boolean value, expose pod on hostNetwork Required when running a custom CNI in managed providers such as AWS EKS See: https://cert-manager.io/docs/installation/compatibility/#aws-eks |
-| app.webhook.nodeSelector | object | `{}` | https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
-| app.webhook.port | int | `10250` | Port that the webhook listens on. |
-| app.webhook.service | object | `{"type":"ClusterIP"}` | Type of Kubernetes Service used by the Webhook |
-| app.webhook.timeoutSeconds | int | `5` | Timeout of webhook HTTP request. |
-| app.webhook.tolerations | list | `[]` | https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
-| commonLabels | object | `{}` | Optional allow custom labels to be placed on resources |
-| image.digest | string | `nil` | Target image digest. Will override any tag if set. for example: digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20 |
-| image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
-| image.registry | string | `nil` | Target image registry. Will be prepended to the target image repositry if set. |
-| image.repository | string | `"quay.io/jetstack/cert-manager-approver-policy"` | Target image repository. |
-| image.tag | string | `nil` | Target image version tag. Defaults to the chart's appVersion. |
-| imagePullSecrets | list | `[]` | Optional secrets used for pulling the approver-policy container image. |
-| podAnnotations | object | `{}` | Optional allow custom annotations to be placed on cert-manager-approver pod |
-| replicaCount | int | `1` | Number of replicas of approver-policy to run. |
-| resources | object | `{}` |  |
-| volumeMounts | list | `[]` | Optional extra volume mounts. Useful for mounting custom root CAs |
-| volumes | list | `[]` | Optional extra volumes. |
+<!-- AUTO-GENERATED -->
 
+
+<table>
+<tr>
+<th>Property</th>
+<th>Description</th>
+<th>Type</th>
+<th>Default</th>
+</tr>
+<tr>
+
+<td>replicaCount</td>
+<td>
+
+Number of replicas of approver-policy to run.
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+1
+```
+
+</td>
+</tr>
+<tr>
+
+<td>image.repository</td>
+<td>
+
+Target image repository.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+quay.io/jetstack/cert-manager-approver-policy
+```
+
+</td>
+</tr>
+<tr>
+
+<td>image.registry</td>
+<td>
+
+Target image registry. Will be prepended to the target image repository if set.
+
+</td>
+<td>unknown</td>
+<td>
+
+```yaml
+null
+```
+
+</td>
+</tr>
+<tr>
+
+<td>image.tag</td>
+<td>
+
+Target image version tag. Defaults to the chart's appVersion.
+
+</td>
+<td>unknown</td>
+<td>
+
+```yaml
+null
+```
+
+</td>
+</tr>
+<tr>
+
+<td>image.digest</td>
+<td>
+
+Target image digest. Will override any tag if set.  
+For example:
+
+```yaml
+digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+```
+
+</td>
+<td>unknown</td>
+<td>
+
+```yaml
+null
+```
+
+</td>
+</tr>
+<tr>
+
+<td>image.pullPolicy</td>
+<td>
+
+Kubernetes imagePullPolicy on Deployment.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+IfNotPresent
+```
+
+</td>
+</tr>
+<tr>
+
+<td>imagePullSecrets</td>
+<td>
+
+Optional secrets used for pulling the approver-policy container image.
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.logLevel</td>
+<td>
+
+Verbosity of approver-policy logging. This is a value from 1 to 5.
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+1
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.extraArgs</td>
+<td>
+
+Extra CLI arguments that will be passed to the approver-policy process.
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.approveSignerNames</td>
+<td>
+
+List if signer names that approver-policy will be given permission to approve and deny. CertificateRequests referencing these signer names can be processed by approver-policy.  
+  
+ref: https://cert-manager.io/docs/concepts/certificaterequest/#approval
+
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+- issuers.cert-manager.io/*
+- clusterissuers.cert-manager.io/*
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.metrics.port</td>
+<td>
+
+Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+9402
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.metrics.service.servicemonitor</td>
+<td>
+
+Create a Service resource to expose metrics endpoint.
+
+</td>
+<td>bool</td>
+<td>
+
+```yaml
+true
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.metrics.service.servicemonitor</td>
+<td>
+
+Service type to expose metrics.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+ClusterIP
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.metrics.service.servicemonitor.enabled</td>
+<td>
+
+Create Prometheus ServiceMonitor resource for approver-policy
+
+</td>
+<td>bool</td>
+<td>
+
+```yaml
+false
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.metrics.service.servicemonitor.prometheusInstance</td>
+<td>
+
+Value for the "prometheus" label on the ServiceMonitor, this allows for multiple Prometheus instances selecting difference ServiceMonitors using label selectors
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+default
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.metrics.service.servicemonitor.interval</td>
+<td>
+
+Interval that the Prometheus will scrape for metrics
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+10s
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.metrics.service.servicemonitor.scrapeTimeout</td>
+<td>
+
+Timeout on each metric probe request
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+5s
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.metrics.service.servicemonitor.labels</td>
+<td>
+
+Additional labels to give the ServiceMonitor resource
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.readinessProbe.port</td>
+<td>
+
+Container port to expose approver-policy HTTP readiness probe on default network interface.
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+6060
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.webhook.host</td>
+<td>
+
+Host that the webhook listens on.
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+0.0.0.0
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.webhook.port</td>
+<td>
+
+Port that the webhook listens on.
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+10250
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.webhook.timeoutSeconds</td>
+<td>
+
+Timeout of webhook HTTP request.
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+5
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.webhook.service.type</td>
+<td>
+
+Type of Kubernetes Service used by the Webhook
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+ClusterIP
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.webhook.hostNetwork</td>
+<td>
+
+Boolean value, expose pod on hostNetwork  
+Required when running a custom CNI in managed providers such as AWS EKS  
+  
+ref: https://cert-manager.io/docs/installation/compatibility/#aws-eks
+
+</td>
+<td>bool</td>
+<td>
+
+```yaml
+false
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.webhook.dnsPolicy</td>
+<td>
+
+May need to be changed if hostNetwork: true
+
+</td>
+<td>string</td>
+<td>
+
+```yaml
+ClusterFirst
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.webhook.affinity</td>
+<td>
+
+A Kubernetes Affinity, if required; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core  
+  
+For example:
+
+```yaml
+affinity:
+  nodeAffinity:
+   requiredDuringSchedulingIgnoredDuringExecution:
+     nodeSelectorTerms:
+     - matchExpressions:
+       - key: foo.bar.com/role
+         operator: In
+         values:
+         - master
+```
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.webhook.nodeSelector</td>
+<td>
+
+The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels. See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>app.webhook.tolerations</td>
+<td>
+
+A list of Kubernetes Tolerations, if required; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core  
+  
+For example:
+
+```yaml
+tolerations:
+- key: foo.bar.com/role
+  operator: Equal
+  value: master
+  effect: NoSchedule
+```
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>volumeMounts</td>
+<td>
+
+Optional extra volume mounts. Useful for mounting custom root CAs  
+  
+For example:
+
+```yaml
+volumeMounts:
+- name: my-volume-mount
+  mountPath: /etc/approver-policy/secrets
+```
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>volumes</td>
+<td>
+
+Optional extra volumes.  
+  
+For example:
+
+```yaml
+volumes:
+- name: my-volume
+  secret:
+    secretName: my-secret
+```
+
+</td>
+<td>array</td>
+<td>
+
+```yaml
+[]
+```
+
+</td>
+</tr>
+<tr>
+
+<td>resources</td>
+<td>
+
+Kubernetes pod resources  
+ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/  
+  
+For example:
+
+```yaml
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+```
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>commonLabels</td>
+<td>
+
+Optional allow custom labels to be placed on resources
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+<tr>
+
+<td>podAnnotations</td>
+<td>
+
+Optional allow custom annotations to be placed on cert-manager-approver pod
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
+```
+
+</td>
+</tr>
+</table>
+
+<!-- /AUTO-GENERATED -->

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -1,110 +1,156 @@
-# -- Number of replicas of approver-policy to run.
+# Number of replicas of approver-policy to run.
 replicaCount: 1
 
 image:
-  # -- Target image repository.
+  # Target image repository.
   repository: quay.io/jetstack/cert-manager-approver-policy
-  # -- Target image registry. Will be prepended to the target image repositry if set.
+  # Target image registry. Will be prepended to the target image repository if set.
   registry:
 
-  # -- Target image version tag. Defaults to the chart's appVersion.
+  # Target image version tag. Defaults to the chart's appVersion.
   tag:
 
-  # -- Target image digest. Will override any tag if set.
-  # for example:
+  # Target image digest. Will override any tag if set.
+  # For example:
   # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
   digest:
 
-  # -- Kubernetes imagePullPolicy on Deployment.
+  # Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 
-# -- Optional secrets used for pulling the approver-policy container image.
+# Optional secrets used for pulling the approver-policy container image.
 imagePullSecrets: []
 
 app:
-  # -- Verbosity of approver-policy logging.
-  logLevel: 1 # 1-5
+  # Verbosity of approver-policy logging. This is a value from 1 to 5.
+  logLevel: 1
 
-  # -- Extra CLI arguments that will be passed to the approver-policy process.
+  # Extra CLI arguments that will be passed to the approver-policy process.
   extraArgs: []
 
-  # -- List if signer names that approver-policy will be given permission to
+  # List if signer names that approver-policy will be given permission to
   # approve and deny. CertificateRequests referencing these signer names can be
-  # processed by approver-policy. See:
-  # https://cert-manager.io/docs/concepts/certificaterequest/#approval
+  # processed by approver-policy. 
+  #
+  # ref: https://cert-manager.io/docs/concepts/certificaterequest/#approval
+  # +docs:property
   approveSignerNames:
   - "issuers.cert-manager.io/*"
   - "clusterissuers.cert-manager.io/*"
 
   metrics:
-    # -- Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.
+    # Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.
     port: 9402
-    # -- Service to expose metrics endpoint.
+    # Service to expose metrics endpoint.
     service:
-      # -- Create a Service resource to expose metrics endpoint.
+      # Create a Service resource to expose metrics endpoint.
       enabled: true
-      # -- Service type to expose metrics.
+      # Service type to expose metrics.
       type: ClusterIP
-      # -- ServiceMonitor resource for this Service.
+      # ServiceMonitor resource for this Service.
       servicemonitor:
+        # Create Prometheus ServiceMonitor resource for approver-policy
         enabled: false
+        # Value for the "prometheus" label on the ServiceMonitor, this allows
+        # for multiple Prometheus instances selecting difference ServiceMonitors 
+        # using label selectors
         prometheusInstance: default
+        # Interval that the Prometheus will scrape for metrics
         interval: 10s
+        # Timeout on each metric probe request
         scrapeTimeout: 5s
+        # Additional labels to give the ServiceMonitor resource
         labels: {}
 
   readinessProbe:
-    # -- Container port to expose approver-policy HTTP readiness probe on
+    # Container port to expose approver-policy HTTP readiness probe on
     # default network interface.
     port: 6060
 
   webhook:
-    # -- Host that the webhook listens on.
+    # Host that the webhook listens on.
     host: 0.0.0.0
-    # -- Port that the webhook listens on.
+
+    # Port that the webhook listens on.
     port: 10250
-    # -- Timeout of webhook HTTP request.
+
+    # Timeout of webhook HTTP request.
     timeoutSeconds: 5
-    # -- Type of Kubernetes Service used by the Webhook
+
     service:
+      # Type of Kubernetes Service used by the Webhook
       type: ClusterIP
-    # -- Boolean value, expose pod on hostNetwork
+
+    # Boolean value, expose pod on hostNetwork
     # Required when running a custom CNI in managed providers such as AWS EKS
-    # See: https://cert-manager.io/docs/installation/compatibility/#aws-eks
+    #
+    # ref: https://cert-manager.io/docs/installation/compatibility/#aws-eks
     hostNetwork: false
-    # -- May need to be changed if hostNetwork: true
+
+    # May need to be changed if hostNetwork: true
     dnsPolicy: ClusterFirst
-    # -- https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+
+    # A Kubernetes Affinity, if required; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core
+    #
+    # For example:
+    #   affinity:
+    #     nodeAffinity:
+    #      requiredDuringSchedulingIgnoredDuringExecution:
+    #        nodeSelectorTerms:
+    #        - matchExpressions:
+    #          - key: foo.bar.com/role
+    #            operator: In
+    #            values:
+    #            - master
     affinity: {}
-    # -- https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+
+    # The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with
+    # matching labels.
+    # See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
     nodeSelector: {}
-    # -- https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+
+    # A list of Kubernetes Tolerations, if required; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core
+    #
+    # For example:
+    #   tolerations:
+    #   - key: foo.bar.com/role
+    #     operator: Equal
+    #     value: master
+    #     effect: NoSchedule
     tolerations: []
 
-# -- Optional extra volume mounts. Useful for mounting custom root CAs
+# Optional extra volume mounts. Useful for mounting custom root CAs
+#
+# For example:
+#  volumeMounts:
+#  - name: my-volume-mount
+#    mountPath: /etc/approver-policy/secrets
 volumeMounts: []
-#- name: my-volume-mount
-#  mountPath: /etc/approver-policy/secrets
 
-# -- Optional extra volumes.
+# Optional extra volumes.
+#
+# For example:
+#  volumes:
+#  - name: my-volume
+#    secret:
+#      secretName: my-secret
 volumes: []
-#- name: my-volume
-#  secret:
-#    secretName: my-secret
 
-
+# Kubernetes pod resources
+# ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+#
+# For example:
+#  resources:
+#    limits:
+#      cpu: 100m
+#      memory: 128Mi
+#    requests:
+#      cpu: 100m
+#      memory: 128Mi
 resources: {}
-  # -- Kubernetes pod resource limits for approver-policy.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # -- Kubernetes pod memory resource requests for approver-policy.
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
-# -- Optional allow custom labels to be placed on resources
+# Optional allow custom labels to be placed on resources
 commonLabels: {}
 
-# -- Optional allow custom annotations to be placed on cert-manager-approver pod
+# Optional allow custom annotations to be placed on cert-manager-approver pod
 podAnnotations: {}

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -36,6 +36,8 @@ api_docs_branch := main
 helm_chart_source_dir := deploy/charts/approver-policy
 helm_chart_name := cert-manager-approver-policy
 helm_chart_version := $(VERSION)
+helm_docs_use_helm_tool := 1
+
 define helm_values_mutation_function
 $(YQ) \
 	'( .image.repository = "$(oci_manager_image_name)" ) | \


### PR DESCRIPTION
This uses helm-tool for the chart README to be consistent with other repos.

The changed readme can be previewed here:
https://github.com/ThatsMrTalbot/cert-manager-approver-policy/blob/docs/helm-tool-for-readme/deploy/charts/approver-policy/README.md

~This PR depends on https://github.com/cert-manager/approver-policy/pull/348 being merged first~ done