### PR TITLE
Remove README header since it is already included in the artifacthub sidebar

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -1,20 +1,8 @@
-# cert-manager-approver-policy
+# approver-policy
 
-approver-policy is a CertificateRequest approver for cert-manager
+<!-- see https://artifacthub.io/packages/helm/cert-manager/cert-manager-approver-policy for the rendered version -->
 
-**Homepage:** <https://cert-manager.io/docs/policy/approval/approver-policy>
-
-## Maintainers
-
-| Name | Email | Url |
-| ---- | ------ | --- |
-| cert-manager-maintainers | <cert-manager-maintainers@googlegroups.com> | <https://cert-manager.io> |
-
-## Source Code
-
-* <https://github.com/cert-manager/approver-policy>
-
-## Values
+## Helm Values
 
 <!-- AUTO-GENERATED -->
 


### PR DESCRIPTION
This is what the new page will look like:
| new | old |
| ---- | ---- |
| <img width="1016" alt="image" src="https://github.com/cert-manager/approver-policy/assets/42113979/a02611d8-4503-47b4-ac9b-e5f09ae4d1bd"> | <img width="1026" alt="image" src="https://github.com/cert-manager/approver-policy/assets/42113979/e7c3776c-6659-43b1-9c7e-698c20f604fc"> |
