### PR TITLE
docs(api): add ticks to Godoc to fix generated API docs

### DIFF
--- a/deploy/charts/approver-policy/templates/crd-policy.cert-manager.io_certificaterequestpolicies.yaml
+++ b/deploy/charts/approver-policy/templates/crd-policy.cert-manager.io_certificaterequestpolicies.yaml
@@ -91,7 +91,7 @@ spec:
                                   Message is the message to display when validation fails.
                                   Message is required if the Rule contains line breaks. Note that Message
                                   must not contain line breaks.
-                                  If unset, a fallback message is used: "failed rule: {Rule}".
+                                  If unset, a fallback message is used: "failed rule: `<rule>`".
                                   e.g. "must be a URL with the host matching spec.host"
                                 type: string
                               rule:
@@ -151,7 +151,7 @@ spec:
                                   Message is the message to display when validation fails.
                                   Message is required if the Rule contains line breaks. Note that Message
                                   must not contain line breaks.
-                                  If unset, a fallback message is used: "failed rule: {Rule}".
+                                  If unset, a fallback message is used: "failed rule: `<rule>`".
                                   e.g. "must be a URL with the host matching spec.host"
                                 type: string
                               rule:
@@ -214,7 +214,7 @@ spec:
                                   Message is the message to display when validation fails.
                                   Message is required if the Rule contains line breaks. Note that Message
                                   must not contain line breaks.
-                                  If unset, a fallback message is used: "failed rule: {Rule}".
+                                  If unset, a fallback message is used: "failed rule: `<rule>`".
                                   e.g. "must be a URL with the host matching spec.host"
                                 type: string
                               rule:
@@ -277,7 +277,7 @@ spec:
                                   Message is the message to display when validation fails.
                                   Message is required if the Rule contains line breaks. Note that Message
                                   must not contain line breaks.
-                                  If unset, a fallback message is used: "failed rule: {Rule}".
+                                  If unset, a fallback message is used: "failed rule: `<rule>`".
                                   e.g. "must be a URL with the host matching spec.host"
                                 type: string
                               rule:
@@ -355,7 +355,7 @@ spec:
                                       Message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
-                                      If unset, a fallback message is used: "failed rule: {Rule}".
+                                      If unset, a fallback message is used: "failed rule: `<rule>`".
                                       e.g. "must be a URL with the host matching spec.host"
                                     type: string
                                   rule:
@@ -418,7 +418,7 @@ spec:
                                       Message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
-                                      If unset, a fallback message is used: "failed rule: {Rule}".
+                                      If unset, a fallback message is used: "failed rule: `<rule>`".
                                       e.g. "must be a URL with the host matching spec.host"
                                     type: string
                                   rule:
@@ -483,7 +483,7 @@ spec:
                                       Message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
-                                      If unset, a fallback message is used: "failed rule: {Rule}".
+                                      If unset, a fallback message is used: "failed rule: `<rule>`".
                                       e.g. "must be a URL with the host matching spec.host"
                                     type: string
                                   rule:
@@ -548,7 +548,7 @@ spec:
                                       Message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
-                                      If unset, a fallback message is used: "failed rule: {Rule}".
+                                      If unset, a fallback message is used: "failed rule: `<rule>`".
                                       e.g. "must be a URL with the host matching spec.host"
                                     type: string
                                   rule:
@@ -611,7 +611,7 @@ spec:
                                       Message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
-                                      If unset, a fallback message is used: "failed rule: {Rule}".
+                                      If unset, a fallback message is used: "failed rule: `<rule>`".
                                       e.g. "must be a URL with the host matching spec.host"
                                     type: string
                                   rule:
@@ -674,7 +674,7 @@ spec:
                                       Message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
-                                      If unset, a fallback message is used: "failed rule: {Rule}".
+                                      If unset, a fallback message is used: "failed rule: `<rule>`".
                                       e.g. "must be a URL with the host matching spec.host"
                                     type: string
                                   rule:
@@ -740,7 +740,7 @@ spec:
                                       Message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
-                                      If unset, a fallback message is used: "failed rule: {Rule}".
+                                      If unset, a fallback message is used: "failed rule: `<rule>`".
                                       e.g. "must be a URL with the host matching spec.host"
                                     type: string
                                   rule:
@@ -802,7 +802,7 @@ spec:
                                       Message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
-                                      If unset, a fallback message is used: "failed rule: {Rule}".
+                                      If unset, a fallback message is used: "failed rule: `<rule>`".
                                       e.g. "must be a URL with the host matching spec.host"
                                     type: string
                                   rule:
@@ -866,7 +866,7 @@ spec:
                                   Message is the message to display when validation fails.
                                   Message is required if the Rule contains line breaks. Note that Message
                                   must not contain line breaks.
-                                  If unset, a fallback message is used: "failed rule: {Rule}".
+                                  If unset, a fallback message is used: "failed rule: `<rule>`".
                                   e.g. "must be a URL with the host matching spec.host"
                                 type: string
                               rule:

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -872,7 +872,7 @@ type ValidationRule struct {
     // Message is the message to display when validation fails.
     // Message is required if the Rule contains line breaks. Note that Message
     // must not contain line breaks.
-    // If unset, a fallback message is used: "failed rule: {Rule}".
+    // If unset, a fallback message is used: "failed rule: `<rule>`".
     // e.g. "must be a URL with the host matching spec.host"
     // +optional
     Message *string `json:"message,omitempty"`

--- a/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
+++ b/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
@@ -258,7 +258,7 @@ type ValidationRule struct {
 	// Message is the message to display when validation fails.
 	// Message is required if the Rule contains line breaks. Note that Message
 	// must not contain line breaks.
-	// If unset, a fallback message is used: "failed rule: {Rule}".
+	// If unset, a fallback message is used: "failed rule: `<rule>`".
 	// e.g. "must be a URL with the host matching spec.host"
 	// +optional
 	Message *string `json:"message,omitempty"`


### PR DESCRIPTION
This PR is the next one in the series of PRs to regenerate approver-policy API docs in our website project, ref. https://github.com/cert-manager/website/pull/1415

/cc @SgtCoDFish 