### PR TITLE
Add optional PodDisruptionBudget to the Helm chart

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -254,6 +254,26 @@ tolerations:
   value: master
   effect: NoSchedule
 ```
+#### **podDisruptionBudget.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Enable or disable the PodDisruptionBudget resource.  
+  
+This prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget blocks `kubectl drain` if it is used on the Node where the only remaining approver-policy  
+Pod is currently running.
+#### **podDisruptionBudget.minAvailable** ~ `number`
+
+Configures the minimum available pods for disruptions.  
+Cannot be used if `maxUnavailable` is set.
+
+#### **podDisruptionBudget.maxUnavailable** ~ `number`
+
+Configures the maximum unavailable pods for disruptions.  
+Cannot be used if `minAvailable` is set.
+
 #### **volumeMounts** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/approver-policy/templates/NOTES.txt
+++ b/deploy/charts/approver-policy/templates/NOTES.txt
@@ -1,0 +1,17 @@
+{{- if (lt (int .Values.replicaCount) 2) }}
+⚠️  WARNING: Consider increasing the Helm value `replicaCount` to 2 if you require high availability.
+{{- end }}
+
+{{- if (not .Values.podDisruptionBudget.enabled) }}
+⚠️  WARNING: Consider setting the Helm value `podDisruptionBudget.enabled` to true if you require high availability.
+{{- end }}
+
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+APP VERSION: {{ .Chart.AppVersion }}
+
+{{ .Chart.Name }} is a cert-manager project.
+
+If you're a new user, we recommend that you read the [cert-manager Approval Policy documentation] to learn more.
+
+[cert-manager Approval Policy documentation]: https://cert-manager.io/docs/policy/approval/

--- a/deploy/charts/approver-policy/templates/_helpers.tpl
+++ b/deploy/charts/approver-policy/templates/_helpers.tpl
@@ -41,3 +41,19 @@ See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linke
 {{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" (default $defaultTag .tag) }}{{- end -}}
 {{- end }}
 {{- end }}
+
+{{/*
+Copied from
+https://github.com/kyverno/kyverno/blob/df5e39c005a78f1ffe6a2eeda3f4497cc9c24384/charts/kyverno/templates/_helpers/_pdb.tpl
+*/}}
+{{- define "cert-manager-approver-policy.pdb.spec" -}}
+{{- if and .minAvailable .maxUnavailable -}}
+  {{- fail "Cannot set both .minAvailable and .maxUnavailable" -}}
+{{- end -}}
+{{- if not .maxUnavailable -}}
+minAvailable: {{ default 1 .minAvailable }}
+{{- end -}}
+{{- if .maxUnavailable -}}
+maxUnavailable: {{ .maxUnavailable }}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/approver-policy/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/approver-policy/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cert-manager-approver-policy.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "cert-manager-approver-policy.labels" . | nindent 4 }}
+spec:
+  {{- include "cert-manager-approver-policy.pdb.spec" .Values.podDisruptionBudget | nindent 2 }}
+  selector:
+    matchLabels:
+      app: {{ include "cert-manager-approver-policy.name" . }}
+{{- end -}}

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -21,6 +21,9 @@
         "podAnnotations": {
           "$ref": "#/$defs/helm-values.podAnnotations"
         },
+        "podDisruptionBudget": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget"
+        },
         "replicaCount": {
           "$ref": "#/$defs/helm-values.replicaCount"
         },
@@ -357,6 +360,34 @@
       "default": {},
       "description": "Allow custom annotations to be placed on cert-manager-approver pod - optional.",
       "type": "object"
+    },
+    "helm-values.podDisruptionBudget": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget.enabled"
+        },
+        "maxUnavailable": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget.maxUnavailable"
+        },
+        "minAvailable": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget.minAvailable"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.podDisruptionBudget.enabled": {
+      "default": false,
+      "description": "Enable or disable the PodDisruptionBudget resource.\n\nThis prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget blocks `kubectl drain` if it is used on the Node where the only remaining approver-policy\nPod is currently running.",
+      "type": "boolean"
+    },
+    "helm-values.podDisruptionBudget.maxUnavailable": {
+      "description": "Configures the maximum unavailable pods for disruptions.\nCannot be used if `minAvailable` is set.",
+      "type": "number"
+    },
+    "helm-values.podDisruptionBudget.minAvailable": {
+      "description": "Configures the minimum available pods for disruptions.\nCannot be used if `maxUnavailable` is set.",
+      "type": "number"
     },
     "helm-values.replicaCount": {
       "default": 1,

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -50,7 +50,7 @@ app:
 
   # List if signer names that approver-policy will be given permission to
   # approve and deny. CertificateRequests referencing these signer names can be
-  # processed by approver-policy. 
+  # processed by approver-policy.
   #
   # ref: https://cert-manager.io/docs/concepts/certificaterequest/#approval
   # +docs:property
@@ -72,7 +72,7 @@ app:
         # Create Prometheus ServiceMonitor resource for approver-policy.
         enabled: false
         # The value for the "prometheus" label on the ServiceMonitor. This allows
-        # for multiple Prometheus instances selecting difference ServiceMonitors 
+        # for multiple Prometheus instances selecting difference ServiceMonitors
         # using label selectors.
         prometheusInstance: default
         # The interval that the Prometheus will scrape for metrics.
@@ -142,6 +142,26 @@ app:
     #     value: master
     #     effect: NoSchedule
     tolerations: []
+
+podDisruptionBudget:
+  # Enable or disable the PodDisruptionBudget resource.
+  #
+  # This prevents downtime during voluntary disruptions such as during a Node upgrade.
+  # For example, the PodDisruptionBudget blocks `kubectl drain`
+  # if it is used on the Node where the only remaining approver-policy
+  # Pod is currently running.
+  enabled: false
+
+  # Configures the minimum available pods for disruptions.
+  # Cannot be used if `maxUnavailable` is set.
+  # +docs:property
+  # minAvailable: 1
+
+  # Configures the maximum unavailable pods for disruptions.
+  # Cannot be used if `minAvailable` is set.
+  # +docs:property
+  # maxUnavailable: 1
+
 
 # Optional extra volume mounts. Useful for mounting custom root CAs.
 #


### PR DESCRIPTION
The platform-engineer who deploys approver-policy using the Helm chart wants to avoid disruption of the approver-policy service when draining a node, for example. 

> [PodDisruptionBudget] ensures that a voluntary disruption, such as the draining of a Node, cannot proceed until at least one other replica has been successfully scheduled and started on another Node. The Helm chart has parameters to enable and configure a PodDisruptionBudget for each of the long-running cert-manager components. 
https://cert-manager.io/docs/installation/best-practice/#poddisruptionbudget

They can use the following values.yaml to achieve this:

```yaml
podDisruptionBudget:
   enabled: true
```


## Testing

### Without enabling PDB

```sh
$ helm upgrade --install -n venafi approver-policy _bin/scratch/image/cert-manager-approver-policy-v0.13.0-alpha.0-11-g6f7f6646bd238c-dirty.tgz
Release "approver-policy" does not exist. Installing it now.
NAME: approver-policy
LAST DEPLOYED: Wed Feb 28 10:09:08 2024
NAMESPACE: venafi
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
⚠️  WARNING: Consider increasing the Helm value `replicaCount` to 2 if you require high availability.
⚠️  WARNING: Consider setting the Helm value `podDisruptionBudget.enabled` to true if you require high availability.

CHART NAME: cert-manager-approver-policy
CHART VERSION: v0.13.0-alpha.0-11-g6f7f6646bd238c-dirty
APP VERSION: v0.13.0-alpha.0-11-g6f7f6646bd238c-dirty

cert-manager-approver-policy is a cert-manager project.

If you're a new user, we recommend that you read the [cert-manager Approval Policy documentation] to learn more.

[cert-manager Approval Policy documentation]: https://cert-manager.io/docs/policy/approval/
```
### With PodDisruptionBudget enabled
```sh
$ helm upgrade --install -n venafi approver-policy _bin/scratch/image/cert-manager-approver-policy-v0.13.0-alpha.0-12-g075790a76f86b9-dirty.tgz  --set replicaCount=2 --set podDisruptionBudget.enabled=true --set image.tag=v0.12.1
Release "approver-policy" has been upgraded. Happy Helming!
NAME: approver-policy
LAST DEPLOYED: Wed Feb 28 10:22:50 2024
NAMESPACE: venafi
STATUS: deployed
REVISION: 4
TEST SUITE: None
NOTES:
CHART NAME: cert-manager-approver-policy
CHART VERSION: v0.13.0-alpha.0-12-g075790a76f86b9-dirty
APP VERSION: v0.13.0-alpha.0-12-g075790a76f86b9-dirty

cert-manager-approver-policy is a cert-manager project.

If you're a new user, we recommend that you read the [cert-manager Approval Policy documentation] to learn more.

[cert-manager Approval Policy documentation]: https://cert-manager.io/docs/policy/approval/
```

