### PR TITLE
Set a size limit on the emptyDir used for /tmp

### DIFF
--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -77,7 +77,8 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       - name: temp-dir
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 50M
 
       hostNetwork: {{ .Values.app.webhook.hostNetwork }}
       dnsPolicy: {{ .Values.app.webhook.dnsPolicy }}


### PR DESCRIPTION
This helps to avoid disk exhaustion attack; 50MB seems to be a reasonable level. Same as used in trust-manager in:
 * https://github.com/cert-manager/trust-manager/pull/308


I can't tell whether I should also add an ephemeral storage resource request.
If that **is** necessary, we can add it in another PR.

This Kyverno Policy suggests that it might be necessary: 
https://main.kyverno.io/policies/other/require-emptydir-requests-limits/require-emptydir-requests-limits/

> Require Requests and Limits for emptyDir
> Pods which mount emptyDir volumes may be allowed to potentially overrun the medium backing the emptyDir volume. This sample ensures that any initContainers or containers mounting an emptyDir volume have ephemeral-storage requests and limits set. Policy will be skipped if the volume has already a sizeLimit set.

## Why does approver-policy need a /tmp directory?

I think the `/tmp` directory is used for the TLS certificate which it generates for the webhook:
 * https://github.com/cert-manager/approver-policy/pull/105

The `/tmp` directory may also be used by some  approver-policy plugins for creating temporary configuration files.

## Further Reading:
 * https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
 * https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#local-ephemeral-storage

