### PR TITLE
Platform engineer can now set Topology Spread Constraints using a Helm chart value

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -254,6 +254,27 @@ tolerations:
   value: master
   effect: NoSchedule
 ```
+#### **topologySpreadConstraints** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+List of Kubernetes TopologySpreadConstraints. For more information, see:  
+[Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).  
+  
+For example:
+
+```yaml
+topologySpreadConstraints:
+- maxSkew: 2
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: ScheduleAnyway
+  labelSelector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager-approver-policy
+      app.kubernetes.io/instance: cert-manager-approver-policy
+```
 #### **podDisruptionBudget.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -94,3 +94,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with  .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -30,6 +30,9 @@
         "resources": {
           "$ref": "#/$defs/helm-values.resources"
         },
+        "topologySpreadConstraints": {
+          "$ref": "#/$defs/helm-values.topologySpreadConstraints"
+        },
         "volumeMounts": {
           "$ref": "#/$defs/helm-values.volumeMounts"
         },
@@ -398,6 +401,12 @@
       "default": {},
       "description": "Kubernetes pod resources.\nFor more information, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
       "type": "object"
+    },
+    "helm-values.topologySpreadConstraints": {
+      "default": [],
+      "description": "List of Kubernetes TopologySpreadConstraints. For more information, see:\n[Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).\n\nFor example:\ntopologySpreadConstraints:\n- maxSkew: 2\n  topologyKey: topology.kubernetes.io/zone\n  whenUnsatisfiable: ScheduleAnyway\n  labelSelector:\n    matchLabels:\n      app.kubernetes.io/name: cert-manager-approver-policy\n      app.kubernetes.io/instance: cert-manager-approver-policy",
+      "items": {},
+      "type": "array"
     },
     "helm-values.volumeMounts": {
       "default": [],

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -143,6 +143,20 @@ app:
     #     effect: NoSchedule
     tolerations: []
 
+# List of Kubernetes TopologySpreadConstraints. For more information, see:
+# [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).
+#
+# For example:
+#   topologySpreadConstraints:
+#   - maxSkew: 2
+#     topologyKey: topology.kubernetes.io/zone
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/name: cert-manager-approver-policy
+#         app.kubernetes.io/instance: cert-manager-approver-policy
+topologySpreadConstraints: []
+
 podDisruptionBudget:
   # Enable or disable the PodDisruptionBudget resource.
   #


### PR DESCRIPTION
The [cert-manager documentation for topology spread constraints](https://cert-manager.io/docs/installation/best-practice/#topology-spread-constraints) says:

> Consider using [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/), to ensure that a disruption of a node or data center does not degrade the operation of cert-manager.
> 
> For high availability you do not want the replica Pods to be scheduled on the same Node, because if that node fails, both the active and standby Pods will exit, and there will be no further reconciliation of the resources by that controller, until there is another Node with sufficient free resources to run a new Pod, and until that Pod has become Ready.
> 
> It is also desirable for the Pods to be running in separate data centers (availability zones), if the cluster has nodes distributed between zones. Then, in the event of a failure at the data center hosting the active Pod , the standby Pod will immediately be available to take leadership.
> 
> Fortunately you may not need to do anything to achieve these goals because [Kubernetes >= 1.24 has Built-in default constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#internal-default-constraints) which should mean that the high availability scheduling described above will happen implicitly.
> 
> ℹ️ In case your cluster does not use Built-in default constraints. You can add [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) to each of the cert-manager components using Helm chart values.

Contrary to what I wrote in that paragraph, approver-policy does not yet have support, so I'm adding it here,
while recognising that it will probably not be widely used, because the cluster defaults will be adequate.


## Testing

* Topology config is omitted by default

```sh
$ helm template _bin/scratch/image/cert-manager-approver-policy-v0.13.0-alpha.0-17-g58168db5f54459.tgz | grep -i topology

```

* But Given the following `values.yaml` file
```sh
# values.yaml
image:
  tag: v0.12.1

replicaCount: 2

podDisruptionBudget:
  enabled: true

topologySpreadConstraints:
- maxSkew: 2
  topologyKey: topology.kubernetes.io/zone
  whenUnsatisfiable: ScheduleAnyway
  labelSelector:
    matchLabels:
      app.kubernetes.io/name: cert-manager-approver-policy
      app.kubernetes.io/instance: cert-manager-approver-policy

app:
  webhook:

    affinity:
      nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
           - key: node-restriction.kubernetes.io/reserved-for
             operator: In
             values:
             - platform

    tolerations:
    - key: node-restriction.kubernetes.io/reserved-for
      operator: Equal
      value: platform

```

* You can see the setting topology settings in the rendered Deployment.

```sh
$ helm template _bin/scratch/image/cert-manager-approver-policy-v0.13.0-alpha.0-17-g58168db5f54459.tgz  --values values.yaml  | grep -C 10 topologySpreadConstraints
          value: platform
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: node-restriction.kubernetes.io/reserved-for
                operator: In
                values:
                - platform
      topologySpreadConstraints:
        - labelSelector:
            matchLabels:
              app.kubernetes.io/instance: cert-manager-approver-policy
              app.kubernetes.io/name: cert-manager-approver-policy
          maxSkew: 2
          topologyKey: topology.kubernetes.io/zone
          whenUnsatisfiable: ScheduleAnyway
---
# Source: cert-manager-approver-policy/templates/webhook.yaml
apiVersion: admissionregistration.k8s.io/v1
```


* And it's accepted by the K8S API server

```sh
$ helm upgrade cert-manager-approver-policy _bin/scratch/image/cert-manager-approver-policy-v0.13.0-alpha.0-17-g58168db5f54459.tgz  --values values.yaml  --namespace venafi --create-namespace --install
Release "cert-manager-approver-policy" does not exist. Installing it now.
NAME: cert-manager-approver-policy
LAST DEPLOYED: Thu Feb 29 09:52:20 2024
NAMESPACE: venafi
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
CHART NAME: cert-manager-approver-policy
CHART VERSION: v0.13.0-alpha.0-17-g58168db5f54459
APP VERSION: v0.13.0-alpha.0-17-g58168db5f54459

cert-manager-approver-policy is a cert-manager project.

If you're a new user, we recommend that you read the [cert-manager Approval Policy documentation] to learn more.

[cert-manager Approval Policy documentation]: https://cert-manager.io/docs/policy/approval/
```


```sh
$ kubectl get -n venafi deployments.apps cert-manager-approver-policy -o yaml | grep -C 10 -i topology
        runAsNonRoot: true
        seccompProfile:
          type: RuntimeDefault
      serviceAccount: cert-manager-approver-policy
      serviceAccountName: cert-manager-approver-policy
      terminationGracePeriodSeconds: 30
      tolerations:
      - key: node-restriction.kubernetes.io/reserved-for
        operator: Equal
        value: platform
      topologySpreadConstraints:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/instance: cert-manager-approver-policy
            app.kubernetes.io/name: cert-manager-approver-policy
        maxSkew: 2
        topologyKey: topology.kubernetes.io/zone
        whenUnsatisfiable: ScheduleAnyway
      volumes:
      - emptyDir:
          sizeLimit: 50M
        name: temp-dir
status:
  conditions:
  - lastTransitionTime: "2024-02-29T09:52:20Z"
    lastUpdateTime: "2024-02-29T09:53:31Z"
    message: ReplicaSet "cert-manager-approver-policy-5d77f4ff49" has successfully
```
