### PR TITLE
Remove emptydir /tmp volume because it is unused

### DIFF
--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -57,12 +57,10 @@ spec:
           - --webhook-service-name={{ include "cert-manager-approver-policy.name" . }}
           - --webhook-ca-secret-namespace={{.Release.Namespace}}
 
-        volumeMounts:
         {{- with .Values.volumeMounts }}
+        volumeMounts:
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        - mountPath: /tmp
-          name: temp-dir
 
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
@@ -72,13 +70,10 @@ spec:
           capabilities: { drop: ["ALL"] }
           readOnlyRootFilesystem: true
 
-      volumes:
       {{- with .Values.volumes }}
+      volumes:
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      - name: temp-dir
-        emptyDir:
-          sizeLimit: 50M
 
       hostNetwork: {{ .Values.app.webhook.hostNetwork }}
       dnsPolicy: {{ .Values.app.webhook.dnsPolicy }}


### PR DESCRIPTION
In https://github.com/cert-manager/approver-policy/pull/298 @inteon stopped using `/tmp` for the dynamically generated webhook key and certificate and deprecated the command line flag which had previously allowed the user to override the directory.

That was released in [v0.10.0](https://github.com/cert-manager/approver-policy/releases/tag/v0.10.0) and now in v0.13.0 we can remove the flag altogether and remove the emptydir volume 

(arguably the emptyDir should have been removed in #298)

Removing this [emptyDir volume](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) will make life easier for platform engineers who install approver-policy because they will no longer have to consider it when choosing [ephemeral storage requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#setting-requests-and-limits-for-local-ephemeral-storage).
And they will no longer have to consider the approver-policy empty dir when draining a node using [kubectl drain](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#drain).