### PR TITLE
Make all Deployment related Helm values global

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -210,6 +210,18 @@ For more information, see [AWS EKS](https://cert-manager.io/docs/installation/co
 
 This value may need to be changed if `hostNetwork: true`
 #### **app.webhook.affinity** ~ `object`
+
+Deprecated. Use .affinity instead.
+
+#### **app.webhook.nodeSelector** ~ `object`
+
+Deprecated. Use .nodeSelector instead.
+
+#### **app.webhook.tolerations** ~ `array`
+
+Deprecated. Use .tolerations instead.
+
+#### **affinity** ~ `object`
 > Default value:
 > ```yaml
 > {}
@@ -230,14 +242,14 @@ affinity:
          values:
          - master
 ```
-#### **app.webhook.nodeSelector** ~ `object`
+#### **nodeSelector** ~ `object`
 > Default value:
 > ```yaml
 > {}
 > ```
 
 The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels. For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
-#### **app.webhook.tolerations** ~ `array`
+#### **tolerations** ~ `array`
 > Default value:
 > ```yaml
 > []

--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -181,34 +181,14 @@ The port that the webhook listens on.
 > ```
 
 The timeout of webhook HTTP request.
-#### **app.webhook.service.type** ~ `string`
-> Default value:
-> ```yaml
-> ClusterIP
-> ```
-
-The type of Kubernetes Service used by the webhook.
-#### **app.webhook.service.nodePort** ~ `number`
-
-The nodePort set on the Service used by the webhook.
-
 #### **app.webhook.hostNetwork** ~ `bool`
-> Default value:
-> ```yaml
-> false
-> ```
 
-Boolean value, expose pod on hostNetwork.  
-Required when running a custom CNI in managed providers such as AWS EKS.  
-  
-For more information, see [AWS EKS](https://cert-manager.io/docs/installation/compatibility/#aws-eks).
+Deprecated. Use .hostNetwork instead.
+
 #### **app.webhook.dnsPolicy** ~ `string`
-> Default value:
-> ```yaml
-> ClusterFirst
-> ```
 
-This value may need to be changed if `hostNetwork: true`
+Deprecated. Use .dnsPolicy instead.
+
 #### **app.webhook.affinity** ~ `object`
 
 Deprecated. Use .affinity instead.
@@ -221,6 +201,34 @@ Deprecated. Use .nodeSelector instead.
 
 Deprecated. Use .tolerations instead.
 
+#### **app.webhook.service.type** ~ `string`
+> Default value:
+> ```yaml
+> ClusterIP
+> ```
+
+The type of Kubernetes Service used by the webhook.
+#### **app.webhook.service.nodePort** ~ `number`
+
+The nodePort set on the Service used by the webhook.
+
+#### **hostNetwork** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Boolean value, expose pod on hostNetwork.  
+Required when running a custom CNI in managed providers such as AWS EKS.  
+  
+For more information, see [AWS EKS](https://cert-manager.io/docs/installation/compatibility/#aws-eks).
+#### **dnsPolicy** ~ `string`
+> Default value:
+> ```yaml
+> ClusterFirst
+> ```
+
+This value may need to be changed if `hostNetwork: true`
 #### **affinity** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/approver-policy/templates/NOTES.txt
+++ b/deploy/charts/approver-policy/templates/NOTES.txt
@@ -6,6 +6,18 @@
 ⚠️  WARNING: Consider setting the Helm value `podDisruptionBudget.enabled` to true if you require high availability.
 {{- end }}
 
+{{- if .Values.app.webhook.affinity }}
+⚠️  WARNING: The Helm value `.app.webhook.affinity` is deprecated. Use `.affinity` instead.
+{{- end }}
+
+{{- if .Values.app.webhook.nodeSelector }}
+⚠️  WARNING: The Helm value `.app.webhook.nodeSelector` is deprecated. Use `.nodeSelector` instead.
+{{- end }}
+
+{{- if .Values.app.webhook.tolerations }}
+⚠️  WARNING: The Helm value `.app.webhook.tolerations` is deprecated. Use `.tolerations` instead.
+{{- end }}
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}

--- a/deploy/charts/approver-policy/templates/NOTES.txt
+++ b/deploy/charts/approver-policy/templates/NOTES.txt
@@ -18,6 +18,14 @@
 ⚠️  WARNING: The Helm value `.app.webhook.tolerations` is deprecated. Use `.tolerations` instead.
 {{- end }}
 
+{{- if .Values.app.webhook.hostNetwork }}
+⚠️  WARNING: The Helm value `.app.webhook.hostNetwork` is deprecated. Use `.hostNetwork` instead.
+{{- end }}
+
+{{- if .Values.app.webhook.dnsPolicy }}
+⚠️  WARNING: The Helm value `.app.webhook.dnsPolicy` is deprecated. Use `.dnsPolicy` instead.
+{{- end }}
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -77,15 +77,15 @@ spec:
 
       hostNetwork: {{ (or .Values.app.webhook.hostNetwork .Values.hostNetwork) }}
       dnsPolicy: {{ (or .Values.app.webhook.dnsPolicy .Values.dnsPolicy) }}
-      {{- with (or .Values.nodeSelector .Values.app.webhook.nodeSelector) }}
+      {{- with (or .Values.app.webhook.nodeSelector .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (or .Values.tolerations .Values.app.webhook.tolerations) }}
+      {{- with (or .Values.app.webhook.tolerations .Values.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (or .Values.affinity .Values.app.webhook.affinity) }}
+      {{- with (or .Values.app.webhook.affinity .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -77,15 +77,15 @@ spec:
 
       hostNetwork: {{ .Values.app.webhook.hostNetwork }}
       dnsPolicy: {{ .Values.app.webhook.dnsPolicy }}
-      {{- with .Values.app.webhook.nodeSelector }}
+      {{- with (or .Values.nodeSelector .Values.app.webhook.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.app.webhook.tolerations }}
+      {{- with (or .Values.tolerations .Values.app.webhook.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.app.webhook.affinity }}
+      {{- with (or .Values.affinity .Values.app.webhook.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -75,8 +75,8 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
 
-      hostNetwork: {{ .Values.app.webhook.hostNetwork }}
-      dnsPolicy: {{ .Values.app.webhook.dnsPolicy }}
+      hostNetwork: {{ (or .Values.app.webhook.hostNetwork .Values.hostNetwork) }}
+      dnsPolicy: {{ (or .Values.app.webhook.dnsPolicy .Values.dnsPolicy) }}
       {{- with (or .Values.nodeSelector .Values.app.webhook.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/approver-policy/values.linter.exceptions
+++ b/deploy/charts/approver-policy/values.linter.exceptions
@@ -1,1 +1,7 @@
 value missing from values.yaml: nameOverride
+
+# Some false postives
+# See https://github.com/cert-manager/helm-tool/issues/27
+value missing from templates: tolerations
+value missing from templates: affinity
+value missing from templates: nodeSelector

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -15,6 +15,12 @@
         "crds": {
           "$ref": "#/$defs/helm-values.crds"
         },
+        "dnsPolicy": {
+          "$ref": "#/$defs/helm-values.dnsPolicy"
+        },
+        "hostNetwork": {
+          "$ref": "#/$defs/helm-values.hostNetwork"
+        },
         "image": {
           "$ref": "#/$defs/helm-values.image"
         },
@@ -240,8 +246,7 @@
       "type": "object"
     },
     "helm-values.app.webhook.dnsPolicy": {
-      "default": "ClusterFirst",
-      "description": "This value may need to be changed if `hostNetwork: true`",
+      "description": "Deprecated. Use .dnsPolicy instead.",
       "type": "string"
     },
     "helm-values.app.webhook.host": {
@@ -250,8 +255,7 @@
       "type": "string"
     },
     "helm-values.app.webhook.hostNetwork": {
-      "default": false,
-      "description": "Boolean value, expose pod on hostNetwork.\nRequired when running a custom CNI in managed providers such as AWS EKS.\n\nFor more information, see [AWS EKS](https://cert-manager.io/docs/installation/compatibility/#aws-eks).",
+      "description": "Deprecated. Use .hostNetwork instead.",
       "type": "boolean"
     },
     "helm-values.app.webhook.nodeSelector": {
@@ -319,6 +323,16 @@
     "helm-values.crds.keep": {
       "default": true,
       "description": "This option makes it so that the \"helm.sh/resource-policy\": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager custom resources\n(Certificates, Issuers, ...) will be removed too by the garbage collector.",
+      "type": "boolean"
+    },
+    "helm-values.dnsPolicy": {
+      "default": "ClusterFirst",
+      "description": "This value may need to be changed if `hostNetwork: true`",
+      "type": "string"
+    },
+    "helm-values.hostNetwork": {
+      "default": false,
+      "description": "Boolean value, expose pod on hostNetwork.\nRequired when running a custom CNI in managed providers such as AWS EKS.\n\nFor more information, see [AWS EKS](https://cert-manager.io/docs/installation/compatibility/#aws-eks).",
       "type": "boolean"
     },
     "helm-values.image": {

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -3,6 +3,9 @@
     "helm-values": {
       "additionalProperties": false,
       "properties": {
+        "affinity": {
+          "$ref": "#/$defs/helm-values.affinity"
+        },
         "app": {
           "$ref": "#/$defs/helm-values.app"
         },
@@ -18,6 +21,9 @@
         "imagePullSecrets": {
           "$ref": "#/$defs/helm-values.imagePullSecrets"
         },
+        "nodeSelector": {
+          "$ref": "#/$defs/helm-values.nodeSelector"
+        },
         "podAnnotations": {
           "$ref": "#/$defs/helm-values.podAnnotations"
         },
@@ -30,6 +36,9 @@
         "resources": {
           "$ref": "#/$defs/helm-values.resources"
         },
+        "tolerations": {
+          "$ref": "#/$defs/helm-values.tolerations"
+        },
         "topologySpreadConstraints": {
           "$ref": "#/$defs/helm-values.topologySpreadConstraints"
         },
@@ -40,6 +49,11 @@
           "$ref": "#/$defs/helm-values.volumes"
         }
       },
+      "type": "object"
+    },
+    "helm-values.affinity": {
+      "default": {},
+      "description": "A Kubernetes Affinity, if required. For more information, see [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core).\n\nFor example:\naffinity:\n  nodeAffinity:\n   requiredDuringSchedulingIgnoredDuringExecution:\n     nodeSelectorTerms:\n     - matchExpressions:\n       - key: foo.bar.com/role\n         operator: In\n         values:\n         - master",
       "type": "object"
     },
     "helm-values.app": {
@@ -222,8 +236,7 @@
       "type": "object"
     },
     "helm-values.app.webhook.affinity": {
-      "default": {},
-      "description": "A Kubernetes Affinity, if required. For more information, see [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core).\n\nFor example:\naffinity:\n  nodeAffinity:\n   requiredDuringSchedulingIgnoredDuringExecution:\n     nodeSelectorTerms:\n     - matchExpressions:\n       - key: foo.bar.com/role\n         operator: In\n         values:\n         - master",
+      "description": "Deprecated. Use .affinity instead.",
       "type": "object"
     },
     "helm-values.app.webhook.dnsPolicy": {
@@ -242,8 +255,7 @@
       "type": "boolean"
     },
     "helm-values.app.webhook.nodeSelector": {
-      "default": {},
-      "description": "The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels. For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).",
+      "description": "Deprecated. Use .nodeSelector instead.",
       "type": "object"
     },
     "helm-values.app.webhook.port": {
@@ -278,8 +290,7 @@
       "type": "number"
     },
     "helm-values.app.webhook.tolerations": {
-      "default": [],
-      "description": "A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).\n\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
+      "description": "Deprecated. Use .tolerations instead.",
       "items": {},
       "type": "array"
     },
@@ -359,6 +370,11 @@
       "items": {},
       "type": "array"
     },
+    "helm-values.nodeSelector": {
+      "default": {},
+      "description": "The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels. For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).",
+      "type": "object"
+    },
     "helm-values.podAnnotations": {
       "default": {},
       "description": "Allow custom annotations to be placed on cert-manager-approver pod - optional.",
@@ -401,6 +417,12 @@
       "default": {},
       "description": "Kubernetes pod resources.\nFor more information, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
       "type": "object"
+    },
+    "helm-values.tolerations": {
+      "default": [],
+      "description": "A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).\n\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
+      "items": {},
+      "type": "array"
     },
     "helm-values.topologySpreadConstraints": {
       "default": [],

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -114,34 +114,46 @@ app:
     # This value may need to be changed if `hostNetwork: true`
     dnsPolicy: ClusterFirst
 
-    # A Kubernetes Affinity, if required. For more information, see [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core).
-    #
-    # For example:
-    #   affinity:
-    #     nodeAffinity:
-    #      requiredDuringSchedulingIgnoredDuringExecution:
-    #        nodeSelectorTerms:
-    #        - matchExpressions:
-    #          - key: foo.bar.com/role
-    #            operator: In
-    #            values:
-    #            - master
-    affinity: {}
+    # Deprecated. Use .affinity instead.
+    # +docs:property
+    # affinity: {}
 
-    # The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with
-    # matching labels.
-    # For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
-    nodeSelector: {}
+    # Deprecated. Use .nodeSelector instead.
+    # +docs:property
+    # nodeSelector: {}
 
-    # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
-    #
-    # For example:
-    #   tolerations:
-    #   - key: foo.bar.com/role
-    #     operator: Equal
-    #     value: master
-    #     effect: NoSchedule
-    tolerations: []
+    # Deprecated. Use .tolerations instead.
+    # +docs:property
+    # tolerations: []
+
+# A Kubernetes Affinity, if required. For more information, see [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core).
+#
+# For example:
+#   affinity:
+#     nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#          - key: foo.bar.com/role
+#            operator: In
+#            values:
+#            - master
+affinity: {}
+
+# The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with
+# matching labels.
+# For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+nodeSelector: {}
+
+# A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
+#
+# For example:
+#   tolerations:
+#   - key: foo.bar.com/role
+#     operator: Equal
+#     value: master
+#     effect: NoSchedule
+tolerations: []
 
 # List of Kubernetes TopologySpreadConstraints. For more information, see:
 # [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -105,14 +105,14 @@ app:
       # +docs:property
       # nodePort: 8080
 
-    # Boolean value, expose pod on hostNetwork.
-    # Required when running a custom CNI in managed providers such as AWS EKS.
-    #
-    # For more information, see [AWS EKS](https://cert-manager.io/docs/installation/compatibility/#aws-eks).
-    hostNetwork: false
 
-    # This value may need to be changed if `hostNetwork: true`
-    dnsPolicy: ClusterFirst
+    # Deprecated. Use .hostNetwork instead.
+    # +docs:property
+    # hostNetwork: false
+
+    # Deprecated. Use .dnsPolicy instead.
+    # +docs:property
+    # dnsPolicy: ClusterFirst
 
     # Deprecated. Use .affinity instead.
     # +docs:property
@@ -125,6 +125,15 @@ app:
     # Deprecated. Use .tolerations instead.
     # +docs:property
     # tolerations: []
+
+# Boolean value, expose pod on hostNetwork.
+# Required when running a custom CNI in managed providers such as AWS EKS.
+#
+# For more information, see [AWS EKS](https://cert-manager.io/docs/installation/compatibility/#aws-eks).
+hostNetwork: false
+
+# This value may need to be changed if `hostNetwork: true`
+dnsPolicy: ClusterFirst
 
 # A Kubernetes Affinity, if required. For more information, see [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core).
 #


### PR DESCRIPTION
Some Deployment related Helm chart values are currently nested under `app.webhook`, which is confusing because the webhook and the controller are both part of a single Deployment.

It's inconsistent with other Deployment related global Helm values in this chart such as resources and volumes and volumeMounts.

It is also inconsistent with the same Helm values in trust-manager, which are global.
 * https://github.com/cert-manager/trust-manager/pull/117

https://github.com/cert-manager/trust-manager/blob/34bb21e768695b4503e8e831e99f5d5ffb53f441/deploy/charts/trust-manager/values.yaml#L110-L135

## Testing 

### Deprecation warnings

```yaml
# values.yaml
image:
  tag: v0.12.1

replicaCount: 2

podDisruptionBudget:
  enabled: true

topologySpreadConstraints:
- maxSkew: 2
  topologyKey: topology.kubernetes.io/zone
  whenUnsatisfiable: ScheduleAnyway
  labelSelector:
    matchLabels:
      app.kubernetes.io/name: cert-manager-approver-policy
      app.kubernetes.io/instance: cert-manager-approver-policy

app:
  webhook:

    hostNetwork: true
    dnsPolicy: ClusterFirstWithHostNet

    nodeSelector:
      kubernetes.io/os: linux


    affinity:
      nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
           - key: node-restriction.kubernetes.io/reserved-for
             operator: In
             values:
             - platform

    tolerations:
    - key: node-restriction.kubernetes.io/reserved-for
      operator: Equal
      value: platform
```

```sh
$ helm upgrade cert-manager-approver-policy deploy/charts/approver-policy  --values values.yaml  --namespace venafi --create-namespace --install
Release "cert-manager-approver-policy" has been upgraded. Happy Helming!
NAME: cert-manager-approver-policy
LAST DEPLOYED: Thu Feb 29 17:02:22 2024
NAMESPACE: venafi
STATUS: deployed
REVISION: 5
TEST SUITE: None
NOTES:
⚠️  WARNING: The Helm value `.app.webhook.affinity` is deprecated. Use `.affinity` instead.
⚠️  WARNING: The Helm value `.app.webhook.nodeSelector` is deprecated. Use `.nodeSelector` instead.
⚠️  WARNING: The Helm value `.app.webhook.tolerations` is deprecated. Use `.tolerations` instead.
⚠️  WARNING: The Helm value `.app.webhook.hostNetwork` is deprecated. Use `.hostNetwork` instead.
⚠️  WARNING: The Helm value `.app.webhook.dnsPolicy` is deprecated. Use `.dnsPolicy` instead.

CHART NAME: cert-manager-approver-policy
CHART VERSION: v0.0.0
APP VERSION: v0.0.0

cert-manager-approver-policy is a cert-manager project.

If you're a new user, we recommend that you read the [cert-manager Approval Policy documentation] to learn more.

[cert-manager Approval Policy documentation]: https://cert-manager.io/docs/policy/approval/
```

### Without values

```sh
$ helm template deploy/charts/approver-policy/ | grep -C 5 -e affinity -e tolerations -e nodeSelector -e hostNetwork -e dnsPolicy
        securityContext:
          allowPrivilegeEscalation: false
          capabilities: { drop: ["ALL"] }
          readOnlyRootFilesystem: true

      hostNetwork: false
      dnsPolicy: ClusterFirst
---
# Source: cert-manager-approver-policy/templates/webhook.yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
```

### Using global values

```sh
$ helm template deploy/charts/approver-policy/ --set-json 'affinity={"foo": "bar"}' --set-json='tolerations=[{}]' --set-json='nodeSelector={"foo": "bar"}' --set hostNetwork=true --set dnsPolicy=foo | grep -C 5 -e affinity -e
tolerations -e nodeSelector -e hostNetwork -e dnsPolicy
        securityContext:
          allowPrivilegeEscalation: false
          capabilities: { drop: ["ALL"] }
          readOnlyRootFilesystem: true

      hostNetwork: true
      dnsPolicy: foo
      nodeSelector:
        foo: bar
      tolerations:
        - {}
      affinity:
        foo: bar
---
# Source: cert-manager-approver-policy/templates/webhook.yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
```

### Using deprecated values
```sh
$ helm template deploy/charts/approver-policy/ --set-json 'app.webhook.affinity={"foo": "bar"}' --set-json='app.webhook.tolerations=[{}]' --set-json='app.webhook.nodeSelector={"foo": "bar"}' --set app.webhook.hostNetwork=true --set app.webhook.dnsPolicy=foo | grep -C 5 -e affinity -e tolerations -e nodeSelector -e hostNetwork -e dnsPolicy
        securityContext:
          allowPrivilegeEscalation: false
          capabilities: { drop: ["ALL"] }
          readOnlyRootFilesystem: true

      hostNetwork: true
      dnsPolicy: foo
      nodeSelector:
        foo: bar
      tolerations:
        - {}
      affinity:
        foo: bar
---
# Source: cert-manager-approver-policy/templates/webhook.yaml
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration

```