### PR TITLE
Allow replicaCount to be set to int or string

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -19,8 +19,8 @@ This option decides if the CRDs should be installed as part of the Helm installa
 > true
 > ```
 
-This option makes it so that the "helm.sh/resource-policy": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager custom resources  
-(Certificates, Issuers, ...) will be removed too by the garbage collector.
+This option makes it so that the "helm.sh/resource-policy": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager-approver-policy custom resources  
+(CertificateRequestPolicy) will be removed too by the garbage collector.
 #### **replicaCount** ~ `number,string,null`
 > Default value:
 > ```yaml

--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -21,13 +21,35 @@ This option decides if the CRDs should be installed as part of the Helm installa
 
 This option makes it so that the "helm.sh/resource-policy": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager custom resources  
 (Certificates, Issuers, ...) will be removed too by the garbage collector.
-#### **replicaCount** ~ `number`
+#### **replicaCount** ~ `number,string,null`
 > Default value:
 > ```yaml
 > 1
 > ```
 
-Number of replicas of approver-policy to run.
+Number of replicas of approver-policy to run.  
+  
+For example:  
+ Use integer to set a fixed number of replicas
+
+```yaml
+replicaCount: 2
+```
+
+Use null, if you want to omit the replicas field and use the Kubernetes default value.
+
+```yaml
+replicaCount: null
+```
+
+Use a string if you want to insert a variable for post-processing of the rendered template.
+
+```yaml
+replicaCount: ${REPLICAS_OVERRIDE:=3}
+```
+
+
+
 #### **image.registry** ~ `string`
 
 Target image registry. This value is prepended to the target image repository, if set.  

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -424,8 +424,7 @@
     },
     "helm-values.replicaCount": {
       "default": 1,
-      "description": "Number of replicas of approver-policy to run.",
-      "type": "number"
+      "description": "Number of replicas of approver-policy to run.\n\nFor example:\n Use integer to set a fixed number of replicas\nreplicaCount: 2\nUse null, if you want to omit the replicas field and use the Kubernetes default value.\nreplicaCount: null\nUse a string if you want to insert a variable for post-processing of the rendered template.\nreplicaCount: ${REPLICAS_OVERRIDE:=3}"
     },
     "helm-values.resources": {
       "default": {},

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -322,7 +322,7 @@
     },
     "helm-values.crds.keep": {
       "default": true,
-      "description": "This option makes it so that the \"helm.sh/resource-policy\": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager custom resources\n(Certificates, Issuers, ...) will be removed too by the garbage collector.",
+      "description": "This option makes it so that the \"helm.sh/resource-policy\": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager-approver-policy custom resources\n(CertificateRequestPolicy) will be removed too by the garbage collector.",
       "type": "boolean"
     },
     "helm-values.dnsPolicy": {

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -11,6 +11,18 @@ crds:
   keep: true
 
 # Number of replicas of approver-policy to run.
+#
+# For example:
+#  Use integer to set a fixed number of replicas
+#   replicaCount: 2
+#
+#  Use null, if you want to omit the replicas field and use the Kubernetes default value.
+#   replicaCount: null
+#
+#  Use a string if you want to insert a variable for post-processing of the rendered template.
+#   replicaCount: ${REPLICAS_OVERRIDE:=3}
+#
+# +docs:type=number,string,null
 replicaCount: 1
 
 image:

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -6,8 +6,8 @@ crds:
   # This option makes it so that the "helm.sh/resource-policy": keep
   # annotation is added to the CRD. This will prevent Helm from uninstalling
   # the CRD when the Helm release is uninstalled.
-  # WARNING: when the CRDs are removed, all cert-manager custom resources
-  # (Certificates, Issuers, ...) will be removed too by the garbage collector.
+  # WARNING: when the CRDs are removed, all cert-manager-approver-policy custom resources
+  # (CertificateRequestPolicy) will be removed too by the garbage collector.
   keep: true
 
 # Number of replicas of approver-policy to run.


### PR DESCRIPTION
This allows @erikgb to continue to use a variable string for the replicaCount field.

I added a [helm-tool type tag](https://github.com/cert-manager/helm-tool?tab=readme-ov-file#tags) to the `replicaCount` value of `number,string,null`, which has the effect of removing the type from the generated Helm JSON schema.
Probably because helm-tool doesn't recognise the type value.

As [discussed on Slack](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1708937118648319) .

```sh
$ helm template deploy/charts/approver-policy/ | grep replicas
  replicas: 1
```

```sh
$ helm template deploy/charts/approver-policy/ --set replicaCount=2 | grep replicas
  replicas: 2
```

```sh
$ helm template deploy/charts/approver-policy/ --set replicaCount='${REPLICAS_OVERRIDE:=3}' | grep replicas
  replicas: ${REPLICAS_OVERRIDE:=3}
```

```sh
$ helm template deploy/charts/approver-policy/ --set replicaCount=null | grep replicas
  replicas:
```