### PR TITLE
Document the nameOverride  Helm chart value and add it to the JSON schema

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -6,6 +6,10 @@
 
 <!-- AUTO-GENERATED -->
 
+#### **nameOverride** ~ `string`
+
+nameOverride replaces the name of the chart in the Chart.yaml file, when this is used to construct Kubernetes object names.
+
 #### **crds.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/approver-policy/values.linter.exceptions
+++ b/deploy/charts/approver-policy/values.linter.exceptions
@@ -1,5 +1,3 @@
-value missing from values.yaml: nameOverride
-
 # Some false postives
 # See https://github.com/cert-manager/helm-tool/issues/27
 value missing from templates: tolerations

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -27,6 +27,9 @@
         "imagePullSecrets": {
           "$ref": "#/$defs/helm-values.imagePullSecrets"
         },
+        "nameOverride": {
+          "$ref": "#/$defs/helm-values.nameOverride"
+        },
         "nodeSelector": {
           "$ref": "#/$defs/helm-values.nodeSelector"
         },
@@ -383,6 +386,10 @@
       "description": "Optional secrets used for pulling the approver-policy container image.",
       "items": {},
       "type": "array"
+    },
+    "helm-values.nameOverride": {
+      "description": "nameOverride replaces the name of the chart in the Chart.yaml file, when this is used to construct Kubernetes object names.",
+      "type": "string"
     },
     "helm-values.nodeSelector": {
       "default": {},

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -1,3 +1,8 @@
+# nameOverride replaces the name of the chart in the Chart.yaml file, when this
+# is used to construct Kubernetes object names.
+# +docs:property
+# nameOverride: approver-policy
+
 crds:
   # This option decides if the CRDs should be installed
   # as part of the Helm installation.


### PR DESCRIPTION
We use the `nameOverride` field in the values.yaml of the Venafi enterprise plugin for approver-policy, to change the name of the Kubernetes resources deployed by the sub-chart.
But the new Helm JSON schema validation doesn't include that field, resulting in the following error:

```sh
  Release "approver-policy-enterprise" does not exist. Installing it now.
  Error: values don't meet the specifications of the schema(s) in the following chart(s):
  cert-manager-approver-policy:
  - (root): Additional property nameOverride is not allowed
...
```

`nameOverride` is a standard field that is created by `helm create`, but it is not documented in the scaffolded chart.
* https://github.com/helm/helm/blob/e007c900ce5f2233c8583565d5ba1b0433b1a213/pkg/chartutil/create.go#L433-L449

```
const defaultHelpers = `{{/*
Expand the name of the chart.
*/}}
{{- define "<CHARTNAME>.name" -}}
{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
{{- end }}


{{/*
Create a default fully qualified app name.
We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
If release name contains chart name it will be used as a full name.
*/}}
{{- define "<CHARTNAME>.fullname" -}}
{{- if .Values.fullnameOverride }}
{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
{{- else }}
{{- $name := default .Chart.Name .Values.nameOverride }}
{{- if contains $name .Release.Name }}
{{- .Release.Name | trunc 63 | trimSuffix "-" }}
{{- else }}
{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
{{- end }}
{{- end }}
{{- end }}

```

Our version is here:

https://github.com/cert-manager/approver-policy/blob/c1b51af39fdc454e9ab1ff3a11839b2d418b21a9/deploy/charts/approver-policy/templates/_helpers.tpl#L1-L6

There's another standard field called `fullNameOverride` which is added by `helm create` but which is missing from the approver-policy chart, and I don't know why.
The purpose of these fields are explained here:
 * https://stackoverflow.com/questions/63838705/what-is-the-difference-between-fullnameoverride-and-nameoverride-in-helm

Relatedly while learning more about this field I found that @smuda has reported a problem with the `nameOverride` field, but I haven't investigated that here.  
 * https://github.com/cert-manager/approver-policy/issues/207