### PR TITLE
Allow Deployment strategy customization when installing the Helm chart

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -406,5 +406,26 @@ Allow custom labels to be placed on resources - optional.
 > ```
 
 Allow custom annotations to be placed on cert-manager-approver pod - optional.
+#### **strategy** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Deployment update strategy for the approver-policy Deployment.  
+  
+This could be needed when deploying approver-policy on each control-plane node and setting anti-affinities to forbid two pods on the same node. In this situation, default values of maxSurge (25% round up to next integer = 1) and maxUnavailable (25% round down to next integer = 0) block the rolling update as the new surge pod can't be scheduled on a control-plane node due to anti-affinities. Setting maxSurge to 0 and maxUnavailable to 1 would solve the problem.  
+  
+For example:
+
+```yaml
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 0
+    maxUnavailable: 1
+```
+
+For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -10,6 +10,10 @@ spec:
   selector:
     matchLabels:
       app: {{ include "cert-manager-approver-policy.name" . }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -48,6 +48,9 @@
         "resources": {
           "$ref": "#/$defs/helm-values.resources"
         },
+        "strategy": {
+          "$ref": "#/$defs/helm-values.strategy"
+        },
         "tolerations": {
           "$ref": "#/$defs/helm-values.tolerations"
         },
@@ -442,6 +445,11 @@
     "helm-values.resources": {
       "default": {},
       "description": "Kubernetes pod resources.\nFor more information, see [Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
+      "type": "object"
+    },
+    "helm-values.strategy": {
+      "default": {},
+      "description": "Deployment update strategy for the approver-policy Deployment.\n\nThis could be needed when deploying approver-policy on each control-plane node and setting anti-affinities to forbid two pods on the same node. In this situation, default values of maxSurge (25% round up to next integer = 1) and maxUnavailable (25% round down to next integer = 0) block the rolling update as the new surge pod can't be scheduled on a control-plane node due to anti-affinities. Setting maxSurge to 0 and maxUnavailable to 1 would solve the problem.\n\nFor example:\nstrategy:\n  type: RollingUpdate\n  rollingUpdate:\n    maxSurge: 0\n    maxUnavailable: 1\nFor more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).",
       "type": "object"
     },
     "helm-values.tolerations": {

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -250,3 +250,23 @@ commonLabels: {}
 
 # Allow custom annotations to be placed on cert-manager-approver pod - optional.
 podAnnotations: {}
+
+# Deployment update strategy for the approver-policy Deployment.
+#
+# This could be needed when deploying approver-policy on each control-plane node
+# and setting anti-affinities to forbid two pods on the same node. In this
+# situation, default values of maxSurge (25% round up to next integer = 1) and
+# maxUnavailable (25% round down to next integer = 0) block the rolling update
+# as the new surge pod can't be scheduled on a control-plane node due to
+# anti-affinities. Setting maxSurge to 0 and maxUnavailable to 1 would solve the
+# problem.
+#
+# For example:
+#  strategy:
+#    type: RollingUpdate
+#    rollingUpdate:
+#      maxSurge: 0
+#      maxUnavailable: 1
+#
+# For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
+strategy: {}


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/1091 @yann-soubeyrand added the following feature to the cert-manager Helm chart:

> This PR modifies cert-manager chart to allow customization of [Deployment strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy). This way one can modify maxSurge and maxUnavailable values.
> 
> This could be needed when deploying cert-manager on each master node and setting affinities to forbid two pods on the same node. In this situation, default values of maxSurge (25% round up to next integer = 1) and maxUnavailable (25% round down to next integer = 0) block cert-manager update as the new surge pod can't be scheduled on a master node due to the anti affinities. Setting maxSurge to 0 and maxUnavailable to 1 would solve the problem.

I've copied Yann's Helm chart feature to the approver-policy chart, 
1. in the interests of increasing consistency between the Helm charts of the cert-manager projects, and 
2. assuming that the same use-case also applies to the approver-policy Deployment,

Yann added that feature 6 years ago and I am unsure whether the additions of [PodDisruptionBudget ](https://github.com/cert-manager/cert-manager/pull/3931)and [TopologySpreadConstraint ](https://github.com/cert-manager/cert-manager/pull/5395) have obsoleted this use-case.


## Testing


```yaml
# values.yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxSurge: 0
    maxUnavailable: 1
```

```sh
$ helm template deploy/charts/approver-policy/ | grep -i strategy

$ helm template deploy/charts/approver-policy/ -f values.yaml | grep -i  -C4 strategy
  replicas: 1
  selector:
    matchLabels:
      app: cert-manager-approver-policy
  strategy:
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
    type: RollingUpdate


$ helm upgrade approver-policy deploy/charts/approver-policy/ --install --namespace cert-manager --create-namespace -f values.yaml
Release "approver-policy" does not exist. Installing it now.
NAME: approver-policy
LAST DEPLOYED: Tue Mar  5 13:17:19 2024
NAMESPACE: cert-manager
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
⚠️  WARNING: Consider increasing the Helm value `replicaCount` to 2 if you require high availability.
⚠️  WARNING: Consider setting the Helm value `podDisruptionBudget.enabled` to true if you require high availability.

CHART NAME: cert-manager-approver-policy
CHART VERSION: v0.0.0
APP VERSION: v0.0.0

cert-manager-approver-policy is a cert-manager project.

If you're a new user, we recommend that you read the [cert-manager Approval Policy documentation] to learn more.

[cert-manager Approval Policy documentation]: https://cert-manager.io/docs/policy/approval/


$ kubectl get deploy -n cert-manager -o yaml | grep -C 4 strategy
    revisionHistoryLimit: 10
    selector:
      matchLabels:
        app: cert-manager-approver-policy
    strategy:
      rollingUpdate:
        maxSurge: 0
        maxUnavailable: 1
      type: RollingUpdate
```