### PR TITLE
Run govulncheck daily to alert us to vulnerabilities in the main branch

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,25 @@
+# Run govulncheck at midnight every night on the main branch,
+# to alert us to recent vulnerabilities which affect the Go code in this
+# project.
+name: govulncheck
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: go-version
+        run: |
+          make print-go-version >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.go-version.outputs.result }}
+
+      - run: make verify-govulncheck

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <a href="https://godoc.org/github.com/cert-manager/approver-policy"><img src="https://godoc.org/github.com/cert-manager/approver-policy?status.svg" alt="approver-policy godoc"></a>
   <a href="https://goreportcard.com/report/github.com/cert-manager/approver-policy"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/cert-manager/approver-policy" /></a>
   <a href="https://artifacthub.io/packages/search?repo=cert-manager"><img alt="Artifact Hub" src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cert-manager" /></a>
+  <a href="https://github.com/cert-manager/approver-policy/actions/workflows/govulncheck.yaml"><img alt="govulncheck" src="https://github.com/cert-manager/approver-policy/actions/workflows/govulncheck.yaml/badge.svg" /></a>
 </p>
 
 # approver-policy

--- a/klone.yaml
+++ b/klone.yaml
@@ -32,6 +32,10 @@ targets:
       repo_ref: main
       repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
       repo_path: modules/generate-verify
+    - folder_name: go
+      repo_url: https://github.com/cert-manager/makefile-modules.git
+      repo_ref: main
+      repo_path: modules/go
     - folder_name: helm
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main

--- a/klone.yaml
+++ b/klone.yaml
@@ -10,64 +10,65 @@ targets:
     - folder_name: api-docs
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/api-docs
     - folder_name: boilerplate
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/boilerplate
     - folder_name: cert-manager
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/cert-manager
     - folder_name: controller-gen
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/controller-gen
     - folder_name: generate-verify
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/generate-verify
     - folder_name: go
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/go
     - folder_name: helm
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/helm
     - folder_name: help
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/help
     - folder_name: kind
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/kind
     - folder_name: klone
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/klone
     - folder_name: oci-image
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/oci-image
     - folder_name: repository-base
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/repository-base
     - folder_name: tools
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: eb6afb7091095df05b83ca62903fb55af0946f5e
+      repo_hash: 099b207048a65c407e9c799e1164fa127e2c1200
       repo_path: modules/tools

--- a/make/_shared/go/01_mod.mk
+++ b/make/_shared/go/01_mod.mk
@@ -1,0 +1,41 @@
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ifndef bin_dir
+$(error bin_dir is not set)
+endif
+
+.PHONY: verify-govulncheck
+## Verify all Go modules for vulnerabilities using govulncheck
+## @category [shared] Generate/ Verify
+#
+# Runs `govulncheck` on all Go modules related to the project.
+# Ignores Go modules among the temporary build artifacts in _bin, to avoid
+# scanning the code of the vendored Go, after running make vendor-go.
+# Ignores Go modules in make/_shared, because those will be checked in centrally
+# in the makefile_modules repository.
+#
+# `verify-govulncheck` not added to the `shared_verify_targets` variable and is
+# not run by `make verify`, because `make verify` is run for each PR, and we do
+# not want new vulnerabilities in existing code to block the merging of PRs.
+# Instead `make verify-govulnecheck` is intended to be run periodically by a CI job.
+verify-govulncheck: | $(NEEDS_GOVULNCHECK)
+	@find . -name go.mod -not \( -path "./$(bin_dir)/*" -or -path "./make/_shared/*" \) -printf '%h\n' \
+		| while read d; do \
+				echo "Running 'GOTOOLCHAIN=go$(VENDORED_GO_VERSION) $(bin_dir)/tools/govulncheck ./...' in directory '$${d}'"; \
+				pushd "$${d}" >/dev/null; \
+				GOTOOLCHAIN=go$(VENDORED_GO_VERSION) $(GOVULNCHECK) ./... || exit; \
+				popd >/dev/null; \
+				echo ""; \
+			done

--- a/make/_shared/go/README.md
+++ b/make/_shared/go/README.md
@@ -1,0 +1,3 @@
+# README
+
+A module for various Go static checks.

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -110,6 +110,8 @@ TOOLS += cmctl=2f75014a7c360c319f8c7c8afe8e9ce33fe26dca
 TOOLS += cmrel=fa10147dadc8c36718b7b08aed6d8c6418eb2
 # https://github.com/golangci/golangci-lint/releases
 TOOLS += golangci-lint=v1.55.2
+# https://pkg.go.dev/golang.org/x/vuln?tab=versions
+TOOLS += govulncheck=v1.0.4
 
 # https://pkg.go.dev/k8s.io/code-generator/cmd?tab=versions
 K8S_CODEGEN_VERSION=v0.29.1
@@ -308,6 +310,7 @@ GO_DEPENDENCIES += helm-tool=github.com/cert-manager/helm-tool
 GO_DEPENDENCIES += cmctl=github.com/cert-manager/cmctl/v2
 GO_DEPENDENCIES += cmrel=github.com/cert-manager/release/cmd/cmrel
 GO_DEPENDENCIES += golangci-lint=github.com/golangci/golangci-lint/cmd/golangci-lint
+GO_DEPENDENCIES += govulncheck=golang.org/x/vuln/cmd/govulncheck
 
 #################
 # go build tags #


### PR DESCRIPTION
Run govulncheck at midnight every night on the main branch to alert us to recent vulnerabilities which affect the Go code in this project.

For example, this would have alerted us to the vulnerabilities in the [Go 1.21.7 which were fixed in Go 1.21.8](https://go.dev/doc/devel/release#go1.21.minor).
The badge would have turned red and [GitHub notifications](https://github.com/notifications) would have been received by maintainers who are subscribed to this project.
The output of the failed action would have looked like:

```sh
Running 'GOTOOLCHAIN=go1.21.7 _bin/tools/govulncheck ./...' in directory '.'
Scanning your code and 1172 packages across 104 dependent modules for known vulnerabilities...

=== Symbol Results ===

Vulnerability #1: GO-2024-2610
    Errors returned from JSON marshaling may break template escaping in
    html/template
  More info: https://pkg.go.dev/vuln/GO-2024-2610
  Standard library
    Found in: html/template@go1.21.7
    Fixed in: html/template@go1.21.8
    Example traces found:
      #1: test/env/env.go:73:24: env.RunControlPlane calls envtest.Environment.Start, which eventually calls template.Template.Execute
      #2: test/env/env.go:90:63: env.RunControlPlane calls webhook.StartWebhookServer, which eventually calls template.Template.ExecuteTemplate

```

Depends on the `make verify-govulncheck` target which was added to makefile_modules in https://github.com/cert-manager/makefile-modules/pull/90:
* https://github.com/cert-manager/makefile-modules/pull/90

## Testing

I've tested the new workflow by updating the default branch of my fork and triggering it there, as explained by @jsoref  in https://github.com/orgs/community/discussions/25746.
Here are the results:
 * https://github.com/wallrj/approver-policy/actions/runs/8281943496

And here's what the new badge in the README file should look like:

[![govulncheck](https://github.com/wallrj/approver-policy/actions/workflows/govulncheck.yaml/badge.svg)](https://github.com/wallrj/approver-policy/actions/workflows/govulncheck.yaml)