### PR TITLE
Helm: add http_proxy, https_proxy, and no_proxy

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -10,6 +10,18 @@
 
 nameOverride replaces the name of the chart in the Chart.yaml file, when this is used to construct Kubernetes object names.
 
+#### **http_proxy** ~ `string`
+
+Configures the HTTP_PROXY environment variable where a HTTP proxy is required.
+
+#### **https_proxy** ~ `string`
+
+Configures the HTTPS_PROXY environment variable where a HTTP proxy is required.
+
+#### **no_proxy** ~ `string`
+
+Configures the NO_PROXY environment variable where a HTTP proxy is required, but certain domains should be excluded.
+
 #### **crds.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -74,6 +74,22 @@ spec:
           capabilities: { drop: ["ALL"] }
           readOnlyRootFilesystem: true
 
+        {{- if or .Values.http_proxy .Values.https_proxy .Values.no_proxy }}
+        env:
+        {{- with .Values.http_proxy }}
+        - name: HTTP_PROXY
+          value: {{ . }}
+        {{- end }}
+        {{- with .Values.https_proxy }}
+        - name: HTTPS_PROXY
+          value: {{ . }}
+        {{- end }}
+        {{- with .Values.no_proxy }}
+        - name: NO_PROXY
+          value: {{ . }}
+        {{- end }}
+        {{- end }}
+
       {{- with .Values.volumes }}
       volumes:
       {{- toYaml . | nindent 6 }}

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -24,6 +24,12 @@
         "hostNetwork": {
           "$ref": "#/$defs/helm-values.hostNetwork"
         },
+        "http_proxy": {
+          "$ref": "#/$defs/helm-values.http_proxy"
+        },
+        "https_proxy": {
+          "$ref": "#/$defs/helm-values.https_proxy"
+        },
         "image": {
           "$ref": "#/$defs/helm-values.image"
         },
@@ -32,6 +38,9 @@
         },
         "nameOverride": {
           "$ref": "#/$defs/helm-values.nameOverride"
+        },
+        "no_proxy": {
+          "$ref": "#/$defs/helm-values.no_proxy"
         },
         "nodeSelector": {
           "$ref": "#/$defs/helm-values.nodeSelector"
@@ -350,6 +359,14 @@
       "description": "Boolean value, expose pod on hostNetwork.\nRequired when running a custom CNI in managed providers such as AWS EKS.\n\nFor more information, see [AWS EKS](https://cert-manager.io/docs/installation/compatibility/#aws-eks).",
       "type": "boolean"
     },
+    "helm-values.http_proxy": {
+      "description": "Configures the HTTP_PROXY environment variable where a HTTP proxy is required.",
+      "type": "string"
+    },
+    "helm-values.https_proxy": {
+      "description": "Configures the HTTPS_PROXY environment variable where a HTTP proxy is required.",
+      "type": "string"
+    },
     "helm-values.image": {
       "additionalProperties": false,
       "properties": {
@@ -401,6 +418,10 @@
     },
     "helm-values.nameOverride": {
       "description": "nameOverride replaces the name of the chart in the Chart.yaml file, when this is used to construct Kubernetes object names.",
+      "type": "string"
+    },
+    "helm-values.no_proxy": {
+      "description": "Configures the NO_PROXY environment variable where a HTTP proxy is required, but certain domains should be excluded.",
       "type": "string"
     },
     "helm-values.nodeSelector": {

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -122,7 +122,6 @@ app:
       # +docs:property
       # nodePort: 8080
 
-
     # Deprecated. Use .hostNetwork instead.
     # +docs:property
     # hostNetwork: false
@@ -280,3 +279,18 @@ podAnnotations: {}
 #
 # For more information, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy).
 strategy: {}
+
+# Use these variables to configure the HTTP_PROXY environment variables.
+
+# Configures the HTTP_PROXY environment variable where a HTTP proxy is required.
+# +docs:property
+# http_proxy: "http://proxy:8080"
+
+# Configures the HTTPS_PROXY environment variable where a HTTP proxy is required.
+# +docs:property
+# https_proxy: "https://proxy:8080"
+
+# Configures the NO_PROXY environment variable where a HTTP proxy is required,
+# but certain domains should be excluded.
+# +docs:property
+# no_proxy: "127.0.0.1,localhost"


### PR DESCRIPTION
The cert-manager Helm chart supports setting `HTTPS_PROXY` env variables since https://github.com/cert-manager/cert-manager/issues/310. But these Helm values are missing in approver-policy. I propose to add them.

> [!NOTE]
>
> Approver-policy doesn't do any external calls that would require an HTTP proxy (for people that need an HTTP proxy for outgoing HTTP traffic), so these new Helm parameters won't be helpful to anyone that is using the upstream version of approver-policy. These Helm parameters are useful for folks that rely on plugins that connect to the internet.

To test this, you can run:

```bash
helm template deploy/charts/venafi-enhanced-issuer \
  --set venafiEnhancedIssuer.manager.image.repository=foo \
  --set venafiEnhancedIssuer.https_proxy=http://localhost:9090
```

You will see:

```yaml
      containers:
      - name: venafi-enhanced-issuer
        env:
          - name: HTTPS_PROXY
            value: http://localhost:9090
```

[VC-31970]: https://venafi.atlassian.net/browse/VC-31970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

```bash
helm template ./deploy/charts/approver-policy/ \
  --set http_proxy=http://localhost:9090 | grep -A10 env:
```

returns:
```yaml
      - name: cert-manager-approver-policy
        env:
        - name: HTTP_PROXY
          value: http://localhost:9090
```

Internal link: [VC-31970](https://venafi.atlassian.net/browse/VC-31970)