### PR TITLE
Default to allowing all signers for approval

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -127,12 +127,10 @@ Extra CLI arguments that will be passed to the approver-policy process.
 #### **app.approveSignerNames** ~ `array`
 > Default value:
 > ```yaml
-> - issuers.cert-manager.io/*
-> - clusterissuers.cert-manager.io/*
+> []
 > ```
 
-List of signer names that approver-policy will be given permission to approve and deny. CertificateRequests referencing these signer names can be processed by approver-policy.  
-  
+List of signer names that approver-policy will be given permission to approve and deny. CertificateRequests referencing these signer names can be processed by approver-policy. Defaults to an empty array, allowing approval for all signers.  
 ref: https://cert-manager.io/docs/concepts/certificaterequest/#approval
 
 #### **app.metrics.port** ~ `number`

--- a/deploy/charts/approver-policy/templates/clusterrole.yaml
+++ b/deploy/charts/approver-policy/templates/clusterrole.yaml
@@ -24,10 +24,12 @@ rules:
 - apiGroups: ["cert-manager.io"]
   resources: ["signers"]
   verbs: ["approve"]
+  {{- with .Values.app.approveSignerNames }}
   resourceNames:
-  {{- range .Values.app.approveSignerNames }}
+  {{- range . }}
    - "{{ . }}"
   {{- end  }}
+  {{- end }}
 
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "clusterroles", "rolebindings", "clusterrolebindings"]

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -108,11 +108,8 @@
       "type": "object"
     },
     "helm-values.app.approveSignerNames": {
-      "default": [
-        "issuers.cert-manager.io/*",
-        "clusterissuers.cert-manager.io/*"
-      ],
-      "description": "List of signer names that approver-policy will be given permission to approve and deny. CertificateRequests referencing these signer names can be processed by approver-policy.\n\nref: https://cert-manager.io/docs/concepts/certificaterequest/#approval",
+      "default": [],
+      "description": "List of signer names that approver-policy will be given permission to approve and deny. CertificateRequests referencing these signer names can be processed by approver-policy. Defaults to an empty array, allowing approval for all signers.\nref: https://cert-manager.io/docs/concepts/certificaterequest/#approval",
       "items": {},
       "type": "array"
     },

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -67,13 +67,11 @@ app:
 
   # List of signer names that approver-policy will be given permission to
   # approve and deny. CertificateRequests referencing these signer names can be
-  # processed by approver-policy.
-  #
+  # processed by approver-policy. Defaults to an empty array, allowing approval
+  # for all signers.
   # ref: https://cert-manager.io/docs/concepts/certificaterequest/#approval
   # +docs:property
-  approveSignerNames:
-  - "issuers.cert-manager.io/*"
-  - "clusterissuers.cert-manager.io/*"
+  approveSignerNames: []
 
   metrics:
     # Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.


### PR DESCRIPTION
Implements the design in https://github.com/cert-manager/approver-policy/pull/415

## Local testing of upgrade

I wanted to sanity check that all users upgrading from default values would get the new value.

I installed approver-policy v0.13.1 and checked the role:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
...
    app.kubernetes.io/version: v0.13.1
    helm.sh/chart: cert-manager-approver-policy-v0.13.1
  name: cert-manager-approver-policy
rules:
...
- apiGroups:
  - cert-manager.io
  resourceNames:
  - issuers.cert-manager.io/*
  - clusterissuers.cert-manager.io/*
  resources:
  - signers
  verbs:
  - approve
...
```

Then built the chart locally on this branch and upgraded to it:

```console
$ make helm-chart

$ helm upgrade -n cert-manager cert-manager-approver-policy ./_bin/scratch/image/cert-manager-approver-policy-v0.13.1-27-g8cd1aa7c27f951.tgz
```

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
...
    app.kubernetes.io/version: v0.13.1-27-g8cd1aa7c27f951
    helm.sh/chart: cert-manager-approver-policy-v0.13.1-27-g8cd1aa7c27f951
  name: cert-manager-approver-policy
rules:
...
- apiGroups:
  - cert-manager.io
  resources:
  - signers
  verbs:
  - approve
...
```