### PR TITLE
Helm: set linux nodeSelector by default

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -308,10 +308,11 @@ affinity:
 #### **nodeSelector** ~ `object`
 > Default value:
 > ```yaml
-> {}
+> kubernetes.io/os: linux
 > ```
 
 The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels. For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+
 #### **tolerations** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -422,7 +422,9 @@
       "type": "string"
     },
     "helm-values.nodeSelector": {
-      "default": {},
+      "default": {
+        "kubernetes.io/os": "linux"
+      },
       "description": "The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels. For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).",
       "type": "object"
     },

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -177,7 +177,9 @@ affinity: {}
 # The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with
 # matching labels.
 # For more information, see [Assigning Pods to Nodes](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
-nodeSelector: {}
+# +docs:property=nodeSelector
+nodeSelector:
+  kubernetes.io/os: linux
 
 # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
 #


### PR DESCRIPTION
Similar to cert-manager and csi-driver-spiffe, set the nodeSelector to kubernetes.io/os: linux by default.