### PR TITLE
Add support for JSON logging format

### DIFF
--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -110,6 +110,13 @@ Kubernetes imagePullPolicy on Deployment.
 > ```
 
 Optional secrets used for pulling the approver-policy container image.
+#### **app.logFormat** ~ `string`
+> Default value:
+> ```yaml
+> text
+> ```
+
+The format of approver-policy logging. Accepted values are text or json.
 #### **app.logLevel** ~ `number`
 > Default value:
 > ```yaml

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 7
         args:
+          - --log-format={{.Values.app.logFormat}}
           - --log-level={{.Values.app.logLevel}}
 
           {{- range .Values.app.extraArgs }}

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -92,6 +92,9 @@
         "extraArgs": {
           "$ref": "#/$defs/helm-values.app.extraArgs"
         },
+        "logFormat": {
+          "$ref": "#/$defs/helm-values.app.logFormat"
+        },
         "logLevel": {
           "$ref": "#/$defs/helm-values.app.logLevel"
         },
@@ -118,6 +121,11 @@
       "description": "Extra CLI arguments that will be passed to the approver-policy process.",
       "items": {},
       "type": "array"
+    },
+    "helm-values.app.logFormat": {
+      "default": "text",
+      "description": "The format of approver-policy logging. Accepted values are text or json.",
+      "type": "string"
     },
     "helm-values.app.logLevel": {
       "default": 1,

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -59,6 +59,8 @@ image:
 imagePullSecrets: []
 
 app:
+  # The format of approver-policy logging. Accepted values are text or json.
+  logFormat: text
   # Verbosity of approver-policy logging. This is a value from 1 to 5.
   logLevel: 1
 


### PR DESCRIPTION
This is basically a rip-off of https://github.com/cert-manager/trust-manager/pull/354 adding support for structured logging (JSON) based on slog.