### PR TITLE
add webhook cert configs

### DIFF
--- a/pkg/internal/cmd/cmd.go
+++ b/pkg/internal/cmd/cmd.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"time"
 
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
 	servertls "github.com/cert-manager/cert-manager/pkg/server/tls"
@@ -67,8 +66,8 @@ func NewCommand(ctx context.Context) *cobra.Command {
 					SecretNamespace: opts.Webhook.CASecretNamespace,
 					SecretName:      "cert-manager-approver-policy-tls",
 					RESTConfig:      opts.RestConfig,
-					CADuration:      time.Hour * 24,
-					LeafDuration:    time.Hour,
+					CADuration:      opts.Webhook.CADuration,
+					LeafDuration:    opts.Webhook.LeafDuration,
 				},
 			}
 

--- a/pkg/internal/cmd/options/options.go
+++ b/pkg/internal/cmd/options/options.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
@@ -122,6 +123,15 @@ type Webhook struct {
 	// CASecretNamespace is the namespace that the
 	// cert-manager-approver-policy-tls Secret is stored.
 	CASecretNamespace string
+
+	// CADuration for webhook server DynamicSource CA.
+	// DynamicSource is upstream cert-manager's CA Provider.
+	// Defaults to 1 year.
+	CADuration time.Duration
+
+	// LeafDuration for webhook server TLS certificates.
+	// Defaults to 7 days.
+	LeafDuration time.Duration
 }
 
 func New() *Options {
@@ -228,6 +238,14 @@ func (o *Options) addWebhookFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Webhook.CASecretNamespace,
 		"webhook-ca-secret-namespace", "cert-manager",
 		"Namespace that the cert-manager-approver-policy-tls Secret is stored.")
+
+	fs.DurationVar(&o.Webhook.CADuration,
+		"webhook-ca-duration", time.Hour*24*365,
+		"Duration for webhook server DynamicSource CA. Defaults to 1 year.")
+
+	fs.DurationVar(&o.Webhook.LeafDuration,
+		"webhook-leaf-cert-duration", time.Hour*24*7,
+		"Duration for webhook server TLS certificates. Defaults to 7 days.")
 
 	var deprecatedCertDir string
 	fs.StringVar(&deprecatedCertDir,


### PR DESCRIPTION
The cert-manager approver-policy webhook server TLS certs ([ref link](https://github.com/cert-manager/approver-policy/blob/main/pkg/internal/cmd/cmd.go#L66)) are configured with cert-manager [dynamic authority](https://github.com/cert-manager/cert-manager/blob/master/pkg/server/tls/authority/authority.go#L56).
Currently the generated CA is valid for 1 day and leaf cert for 1 hr (which is rotated [1/3 of the time before](https://github.com/cert-manager/cert-manager/blob/master/pkg/server/tls/dynamic_source.go#L281) expiry i.e. every 40 mins).

This PR makes the webhook server dynamic_source CA duration and leaf certificate duration as configurable. It also makes the default CA Duration as 1 year and default leaf certificate duration as 7 days. 

## Testing

Tested in local KinD cluster, 

```
✗ k get secrets -n cert-manager
NAME                                 TYPE                 DATA   AGE
cert-manager-approver-policy-tls     Opaque               3      21h
...

```

<details><summary>Details: Cert-Manager-approver-policy-tls secret and CA Certificate Default Duration</summary>
<p>

```
✗ k get secret -n cert-manager cert-manager-approver-policy-tls -oyaml
apiVersion: v1
data:
  ca.crt: LS0tLS1C<...redacted...>UtLS0tLQo=
  tls.crt: LS0tL<..redacted..>NBVEUtLS0tLQo=
  tls.key: LS0tLS<..redacted ...>S0VZLS0tLS0K
kind: Secret
metadata:
  annotations:
    cert-manager.io/allow-direct-injection: "true"
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Secret","metadata":{"annotations":{"cert-manager.io/allow-direct-injection":"true"},"labels":{"app":"cert-manager-approver-policy","app.kubernetes.io/instance":"cert-manager-approver-policy","app.kubernetes.io/managed-by":"Helm","app.kubernetes.io/name":"cert-manager-approver-policy","app.kubernetes.io/version":"0.0.77","helm.sh/chart":"cert-manager-approver-policy-v0.0.0"},"name":"cert-manager-approver-policy-tls","namespace":"cert-manager"}}
  creationTimestamp: "2024-06-28T21:46:08Z"
  labels:
    app: cert-manager-approver-policy
    app.kubernetes.io/instance: cert-manager-approver-policy
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: cert-manager-approver-policy
    app.kubernetes.io/version: 0.0.77
    helm.sh/chart: cert-manager-approver-policy-v0.0.0
  name: cert-manager-approver-policy-tls
  namespace: cert-manager
  resourceVersion: "4501010"
  uid: 94791c01-779f-44a8-92e0-e83832c1dac1
type: Opaque


# Default Duration of the CA Certificate is 1 year
✗ echo "LS0tLS1CRUdJTiBDR<...redacted...>NBVEUtLS0tLQo=" | base64 -d | openssl x509 -text - | grep 'Not Before\|Not After\|Subject'
            Not Before: Jun 28 21:46:09 2024 GMT
            Not After : Jun 28 21:46:09 2025 GMT
        Subject: CN=cert-manager-webhook-ca
        Subject Public Key Info:
            X509v3 Subject Key Identifier:

``` 

</p>
</details> 

<details><summary>Details: Describe Approver-Policy Pod in local kind cluster</summary>
<p>

```
✗ k describe pod cert-manager-approver-policy-7bc58774d6-mwg8p -n cert-manager
Name:         cert-manager-approver-policy-7bc58774d6-mwg8p
Namespace:    cert-manager
Priority:     0
Node:         rgodha-local-worker2/172.18.0.3
Start Time:   Fri, 28 Jun 2024 14:46:08 -0700
Labels:       app=cert-manager-approver-policy
              app.kubernetes.io/instance=cert-manager-approver-policy
              app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/name=cert-manager-approver-policy
              app.kubernetes.io/version=0.0.77
              helm.sh/chart=cert-manager-approver-policy-v0.0.0
              pod-template-hash=7bc58774d6
Annotations:  <none>
Status:       Running
IP:           10.244.1.24
IPs:
  IP:           10.244.1.24
Controlled By:  ReplicaSet/cert-manager-approver-policy-7bc58774d6
Containers:
  li-cert-manager-approver-policy:
    Container ID:  containerd://277704d557ec4437729c1a7207c6d07bab7a01bb30625d7425f92fdaf6fd03a5
    Image:         cert-manager/cert-manager-approver:0.0.77
    Image ID:      docker.io/library/import-2024-06-28@sha256:26a62b26a4c7d00baca0179e2b4ee9ff905fbc4ff52a32dc6f715fd1eb36b1fd
    Ports:         10250/TCP, 9402/TCP
    Host Ports:    0/TCP, 0/TCP
    Args:
      --log-level=3
      --metrics-bind-address=:9402
      --readiness-probe-bind-address=:6060
      --webhook-host=0.0.0.0
      --webhook-port=10250
      --webhook-service-name=cert-manager-approver-policy
      --webhook-ca-secret-namespace=cert-manager
    State:          Running
      Started:      Fri, 28 Jun 2024 14:46:09 -0700
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     1
      memory:  4096M
    Requests:
      cpu:        500m
      memory:     1024M
    Readiness:    http-get http://:6060/readyz delay=3s timeout=1s period=7s #success=1 #failure=3
    Environment:  <none>
    Mounts:
      /tmp from temp-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-ppm55 (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True
  Initialized                 True
  Ready                       True
  ContainersReady             True
  PodScheduled                True
Volumes:
  temp-dir:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
  kube-api-access-ppm55:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   Burstable
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:                      <none>
``` 

</p>
</details> 
