### PR TITLE
BUGFIX: Avoid duplicate Prometheus scrape targets by using a named port in the ServiceMonitor

### DIFF
--- a/deploy/charts/approver-policy/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/approver-policy/templates/metrics-servicemonitor.yaml
@@ -20,7 +20,7 @@ spec:
     matchNames:
       - {{ .Release.Namespace }}
   endpoints:
-  - targetPort: {{ .Values.app.metrics.port }}
+  - port: metrics
     path: "/metrics"
     interval: {{ .Values.app.metrics.service.servicemonitor.interval }}
     scrapeTimeout: {{ .Values.app.metrics.service.servicemonitor.scrapeTimeout }}


### PR DESCRIPTION
In https://github.com/cert-manager/approver-policy/pull/229 @leotomas837 reported that:
> The ServiceMonitor targets both the web hook service and the metrics service. Yet, only the metrics service must be scraped (the probe could be scraped too via the blackbox-exporter, but that is a subject for another PR). The webhook service must not be discovered by Prometheus.

In that original PR, we tried to fix this by modifying the labels in the Service and ServiceMonitor, but while testing it we found a simpler solution, which is to specify a port **name** in the ServiceMonitor.

Before
<img width="960" alt="Screenshot 2024-07-25 094542" src="https://github.com/user-attachments/assets/66ad6c0a-100f-4eda-9460-45fad53d2a9b">

After
<img width="960" alt="Screenshot 2024-07-25 100019" src="https://github.com/user-attachments/assets/d853d65c-1bbb-44a3-abdf-8759e962b9b6">


## Testing
You can test this yourself as follows:

```sh
# Start a Kind cluster and install approver-policy (from source) + cert-manager
make test-smoke-deps

# Deploy  Prometheus
helm upgrade default kube-prometheus-stack \
    --repo https://prometheus-community.github.io/helm-charts \
    --install \
    --namespace prometheus \
    --create-namespace \
    --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
    --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
    --wait

# Redeploy approver-policy with ServiceMonitor enabled
make test-smoke-deps \
  INSTALL_OPTIONS="--set image.repository=\$(oci_manager_image_name_development) --set app.metrics.service.servicemonitor.enabled=true"

# Connect to prometheus web UI
kubectl port-forward -n prometheus pods/prometheus-default-kube-prometheus-st-prometheus-0 9090
```

Visit: http://localhost:9090/targets