### PR TITLE
Add erikgb to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,7 @@ approvers:
 - irbekrm
 - sgtcodfish
 - inteon
+- erikgb
 reviewers:
 - munnerz
 - joshvanl


### PR DESCRIPTION
When attempting to approve https://github.com/cert-manager/approver-policy/pull/489 I noticed that my approval didn't count. 😅 Since my vote to become a cert-manager maintainer is now accepted, ref. https://github.com/cert-manager/community/pull/32, this PR should require a simple approval. 🙏 

/cc @inteon 