### PR TITLE
fix: apply cert-manager default issuer kind/group when matching policies

### DIFF
--- a/pkg/internal/controllers/test/selector.go
+++ b/pkg/internal/controllers/test/selector.go
@@ -198,10 +198,6 @@ var _ = Context("Selector", func() {
 			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Name: "my-issuer"}),
 		)
 		waitForApproval(ctx, env.AdminClient, namespace.Name, crName)
-		crName = createCertificateRequest(ctx, env.UserClient, namespace.Name, gen.SetCSRDNSNames(),
-			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Name: "my-issuer-2"}),
-		)
-		waitForNoApproveOrDeny(ctx, env.AdminClient, namespace.Name, crName)
 
 		deleteRoleAndRoleBindings(ctx, namespace.Name, userUsePolicyRoleName, userCreateCRRoleName)
 	})

--- a/pkg/internal/controllers/test/selector.go
+++ b/pkg/internal/controllers/test/selector.go
@@ -170,6 +170,42 @@ var _ = Context("Selector", func() {
 		deleteRoleAndRoleBindings(ctx, namespace.Name, userUsePolicyRoleName, userCreateCRRoleName)
 	})
 
+	It("it should select on CertificateRequests with issuerRef={name=my-issuer} where issuerRef={name=my-issuer kind=Issuer group=cert-manager.io}, RBAC bound, and plugin return Ready", func() {
+		plugin.FakeReconciler = fake.NewFakeReconciler().WithReady(func(_ context.Context, policy *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
+			return approver.ReconcilerReadyResponse{Ready: true}, nil
+		})
+
+		policy := policyapi.CertificateRequestPolicy{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "selector-"},
+			Spec: policyapi.CertificateRequestPolicySpec{
+				Selector: policyapi.CertificateRequestPolicySelector{
+					IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{
+						Name: ptr.To("my-issuer"), Kind: ptr.To("Issuer"), Group: ptr.To("cert-manager.io"),
+					},
+				},
+				Plugins: map[string]policyapi.CertificateRequestPolicyPluginData{
+					"test-plugin": {},
+				},
+			},
+		}
+		Expect(env.AdminClient.Create(ctx, &policy)).ToNot(HaveOccurred())
+		waitForReady(ctx, env.AdminClient, policy.Name)
+
+		userCreateCRRoleName := bindUserToCreateCertificateRequest(ctx, env.AdminClient, namespace.Name)
+		userUsePolicyRoleName := bindUserToUseCertificateRequestPolicies(ctx, env.AdminClient, namespace.Name, policy.Name)
+
+		crName := createCertificateRequest(ctx, env.UserClient, namespace.Name, gen.SetCSRDNSNames(),
+			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Name: "my-issuer"}),
+		)
+		waitForApproval(ctx, env.AdminClient, namespace.Name, crName)
+		crName = createCertificateRequest(ctx, env.UserClient, namespace.Name, gen.SetCSRDNSNames(),
+			gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{Name: "my-issuer-2"}),
+		)
+		waitForNoApproveOrDeny(ctx, env.AdminClient, namespace.Name, crName)
+
+		deleteRoleAndRoleBindings(ctx, namespace.Name, userUsePolicyRoleName, userCreateCRRoleName)
+	})
+
 	It("it should not select on CertificateRequests where the IssuerRef does not match", func() {
 		plugin.FakeReconciler = fake.NewFakeReconciler().WithReady(func(_ context.Context, policy *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
 			return approver.ReconcilerReadyResponse{Ready: true}, nil


### PR DESCRIPTION
This PR makes approver-policy adhere to the cert-manager controller defaults for issuer `kind`/`group`.

When referencing issuers in cert-manager `Certificate` and `CertificateRequest`, the issuerRef `kind` and `group` are optional and defaulted in the cert-manager controller (a.k.a. controller defaults). This becomes problematic in approver-policy if you want to enforce a policy addressing cert-manager issuers. Example (irrelevant details omitted):

Policy:
````yaml
apiVersion: policy.cert-manager.io/v1alpha1
kind: CertificateRequestPolicy
metadata:
  name: allow-all-cert-manager-issuers
spec:
  selector:
    issuerRef:
      group: cert-manager.io
      kind: Issuer
````

Certificate:
````yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: my-cert
spec:
  issuerRef:
    name: my-issuer
````

This kind of simple certificate is common in operators using kubebuilder/operator-sdk for development. The reason probably being to keep the scaffolding in these CLI tools as simple as possible,

Expected behavior: The policy matches certificate requests because cert-manager defaults match policy issuerRef `group` and `kind`.

Actual behavior: Policy doesn't select the requests ending up in never-approved requests. 😒 


Possible workaround: Use a mutating webhook to materialize the cert-manager controller defaults into cert-manager resources. Tutorial: https://cert-manager.io/docs/tutorials/certificate-defaults/. I am personally not a big fan of this workaround, as every webhook call increases the operational risk of outages in your cluster.

This issue was also discussed in this long thread on [Slack](https://kubernetes.slack.com/archives/C4NV3DWUC/p1723537145338019), even if it turned out to not be the root cause of the issue that started the thread.