### PR TITLE
BUGFIX: Webhook CA Secret name should match Helm templated RBAC

### DIFF
--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -61,6 +61,7 @@ spec:
           - --webhook-port={{.Values.app.webhook.port}}
           - --webhook-service-name={{ include "cert-manager-approver-policy.name" . }}
           - --webhook-ca-secret-namespace={{.Release.Namespace}}
+          - --webhook-ca-secret-name={{ include "cert-manager-approver-policy.name" . }}-tls
 
         {{- with .Values.volumeMounts }}
         volumeMounts:

--- a/pkg/internal/cmd/cmd.go
+++ b/pkg/internal/cmd/cmd.go
@@ -64,7 +64,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				DNSNames: []string{fmt.Sprintf("%s.%s.svc", opts.Webhook.ServiceName, opts.Webhook.CASecretNamespace)},
 				Authority: &authority.DynamicAuthority{
 					SecretNamespace: opts.Webhook.CASecretNamespace,
-					SecretName:      "cert-manager-approver-policy-tls",
+					SecretName:      opts.Webhook.CASecretName,
 					RESTConfig:      opts.RestConfig,
 					CADuration:      opts.Webhook.CADuration,
 					LeafDuration:    opts.Webhook.LeafDuration,

--- a/pkg/internal/cmd/options/options.go
+++ b/pkg/internal/cmd/options/options.go
@@ -120,9 +120,13 @@ type Webhook struct {
 	// ServiceName is the service that exposes the Webhook server.
 	ServiceName string
 
-	// CASecretNamespace is the namespace that the
-	// cert-manager-approver-policy-tls Secret is stored.
+	// CASecretName is the namespace that the approver-policy
+	// webhook CA certificate Secret is stored.
 	CASecretNamespace string
+
+	// CASecretName is the name of the Secret use to store
+	// the approver-policy webhook CA certificate.
+	CASecretName string
 
 	// CADuration for webhook server DynamicSource CA.
 	// DynamicSource is upstream cert-manager's CA Provider.
@@ -237,7 +241,11 @@ func (o *Options) addWebhookFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&o.Webhook.CASecretNamespace,
 		"webhook-ca-secret-namespace", "cert-manager",
-		"Namespace that the cert-manager-approver-policy-tls Secret is stored.")
+		"Namespace that the approver-policy webhook CA certificate Secret is stored.")
+
+	fs.StringVar(&o.Webhook.CASecretName,
+		"webhook-ca-secret-name", "cert-manager-approver-policy-tls",
+		"Name of Secret used to store the approver-policy webhook CA certificate Secret.")
 
 	fs.DurationVar(&o.Webhook.CADuration,
 		"webhook-ca-duration", time.Hour*24*365,


### PR DESCRIPTION
It seems like we forgot an important detail when tightening the RBAC to secrets in controller namespace. 😅 

Fixes https://github.com/cert-manager/approver-policy/issues/207