### PR TITLE
Add Helm chart OCI release to GH automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ env:
   VERSION: ${{ github.ref_name }}
 
 jobs:
-  build_images:
+  build_and_push:
     runs-on: ubuntu-latest
 
     permissions:
@@ -36,22 +36,16 @@ jobs:
       - id: release
         run: make release
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.release.outputs.RELEASE_HELM_CHART_NAME }}-${{ steps.release.outputs.RELEASE_HELM_CHART_VERSION }}.tgz
-          path: ${{ steps.release.outputs.RELEASE_HELM_CHART_TAR }}
-          if-no-files-found: error
-
     outputs:
       RELEASE_OCI_MANAGER_IMAGE: ${{ steps.release.outputs.RELEASE_OCI_MANAGER_IMAGE }}
       RELEASE_OCI_MANAGER_TAG: ${{ steps.release.outputs.RELEASE_OCI_MANAGER_TAG }}
-      RELEASE_HELM_CHART_NAME: ${{ steps.release.outputs.RELEASE_HELM_CHART_NAME }}
+      RELEASE_HELM_CHART_IMAGE: ${{ steps.release.outputs.RELEASE_HELM_CHART_IMAGE }}
       RELEASE_HELM_CHART_VERSION: ${{ steps.release.outputs.RELEASE_HELM_CHART_VERSION }}
 
   github_release:
     runs-on: ubuntu-latest
 
-    needs: build_images
+    needs: build_and_push
 
     permissions:
       contents: write # needed for creating a PR
@@ -60,15 +54,10 @@ jobs:
     steps:
       - run: |
           touch .notes-file
-          echo "OCI_MANAGER_IMAGE: ${{ needs.build_images.outputs.RELEASE_OCI_MANAGER_IMAGE }}" >> .notes-file
-          echo "OCI_MANAGER_TAG: ${{ needs.build_images.outputs.RELEASE_OCI_MANAGER_TAG }}" >> .notes-file
-          echo "HELM_CHART_NAME: ${{ needs.build_images.outputs.RELEASE_HELM_CHART_NAME }}" >> .notes-file
-          echo "HELM_CHART_VERSION: ${{ needs.build_images.outputs.RELEASE_HELM_CHART_VERSION }}" >> .notes-file
-
-      - id: chart_download
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.build_images.outputs.RELEASE_HELM_CHART_NAME }}-${{ needs.build_images.outputs.RELEASE_HELM_CHART_VERSION }}.tgz
+          echo "OCI_MANAGER_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_OCI_MANAGER_IMAGE }}" >> .notes-file
+          echo "OCI_MANAGER_TAG: ${{ needs.build_and_push.outputs.RELEASE_OCI_MANAGER_TAG }}" >> .notes-file
+          echo "HELM_CHART_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_IMAGE }}" >> .notes-file
+          echo "HELM_CHART_VERSION: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_VERSION }}" >> .notes-file
 
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,7 +68,3 @@ jobs:
             --draft \
             --verify-tag \
             --notes-file .notes-file
-          
-          gh release upload "$VERSION" \
-            --repo="$GITHUB_REPOSITORY" \
-            "${{ steps.chart_download.outputs.download-path }}/${{ needs.build_images.outputs.RELEASE_HELM_CHART_NAME }}-${{ needs.build_images.outputs.RELEASE_HELM_CHART_VERSION }}.tgz"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,24 +18,21 @@ The release process for this repo is documented below:
    ```
 2. A GitHub action will see the new tag and do the following:
     - Build and publish any container images
-    - Build and bundle the Helm chart
+    - Build and publish the Helm chart
     - Create a draft GitHub release
-    - Upload the Helm chart tarball to the GitHub release
-3. Once the draft GitHub release has been created, download and test the resulting Helm chart.
-4. Create a PR in the [jetstack/jetstack-charts repository on GitHub](https://github.com/jetstack/jetstack-charts), containing the Helm chart file that is attached to the draft GitHub release. This is only currently possible for maintainers inside Venafi, but will be changed in the future.
-5. Wait for the PR to be merged and verify that the Helm chart is available from https://charts.jetstack.io.
-6. Visit the [releases page], edit the draft release, click "Generate release notes", then edit the notes to add the following to the top
+3. Wait for the PR to be merged and wait for OCI Helm chart to propagate and become available from https://charts.jetstack.io (this might take a few hours).
+4. Visit the [releases page], edit the draft release, click "Generate release notes", then edit the notes to add the following to the top
     ```
     approver-policy provides a policy engine for certificates issued by cert-manager!
     ```
-7. Publish the release.
+5. Publish the release.
 
 ## Artifacts
 
 This repo will produce the following artifacts each release. For documentation on how those artifacts are produced see the "Process" section.
 
-- *Container Images* - Container images for the are published to . 
-- *Helm chart* - An official Helm chart is maintained within this repo and published to `charts.jetstack.io` on each release.
+- *Container Images* - Container images for the are published to `quay.io/jetstack`. 
+- *Helm chart* - An official Helm chart is maintained within this repo and published to `quay.io/jetstack` and `charts.jetstack.io` on each release.
 
 [release workflow]: https://github.com/cert-manager/approver-policy/actions/workflows/release.yaml
 [releases page]: https://github.com/cert-manager/approver-policy/releases

--- a/klone.yaml
+++ b/klone.yaml
@@ -35,7 +35,7 @@ targets:
     - folder_name: helm
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 6eccdeac5eab23905699243209e0f81afad6f081
+      repo_hash: fbd26411777b12c2574d05f146cee617c6c50b63
       repo_path: modules/helm
     - folder_name: help
       repo_url: https://github.com/cert-manager/makefile-modules.git

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -31,12 +31,9 @@ deploy_name := approver-policy
 deploy_namespace := cert-manager
 
 helm_chart_source_dir := deploy/charts/approver-policy
-helm_chart_name := cert-manager-approver-policy
+helm_chart_image_name := quay.io/jetstack/charts/cert-manager-approver-policy
 helm_chart_version := $(VERSION)
 helm_labels_template_name := cert-manager-approver-policy.labels
-helm_docs_use_helm_tool := 1
-helm_generate_schema := 1
-helm_verify_values := 1
 
 golangci_lint_config := .golangci.yaml
 

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -32,13 +32,13 @@ include make/test-unit.mk
 .PHONY: release
 ## Publish all release artifacts (image + helm chart)
 ## @category [shared] Release
-release: $(helm_chart_archive)
+release:
 	$(MAKE) oci-push-manager
+	$(MAKE) helm-chart-oci-push
 
 	@echo "RELEASE_OCI_MANAGER_IMAGE=$(oci_manager_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_MANAGER_TAG=$(oci_manager_image_tag)" >> "$(GITHUB_OUTPUT)"
-	@echo "RELEASE_HELM_CHART_NAME=$(helm_chart_name)" >> "$(GITHUB_OUTPUT)"
+	@echo "RELEASE_HELM_CHART_IMAGE=$(helm_chart_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_HELM_CHART_VERSION=$(helm_chart_version)" >> "$(GITHUB_OUTPUT)"
-	@echo "RELEASE_HELM_CHART_TAR=$(helm_chart_archive)" >> "$(GITHUB_OUTPUT)"
 
 	@echo "Release complete!"

--- a/make/_shared/helm/crds.mk
+++ b/make/_shared/helm/crds.mk
@@ -40,32 +40,35 @@ endif
 crds_dir ?= deploy/crds
 crds_dir_readme := $(dir $(lastword $(MAKEFILE_LIST)))/crds_dir.README.md
 
-$(crds_dir):
-	mkdir -p $@
-
-$(crds_dir)/README.md: $(crds_dir_readme) | $(crds_dir)
-	cp $< $@
-
 .PHONY: generate-crds
 ## Generate CRD manifests.
 ## @category [shared] Generate/ Verify
-generate-crds: | $(crds_dir)/README.md $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
+generate-crds: | $(NEEDS_CONTROLLER-GEN) $(NEEDS_YQ)
+	$(eval crds_gen_temp := $(bin_dir)/scratch/crds)
 	$(eval directories := $(shell ls -d */ | grep -v -e 'make' $(shell git check-ignore -- * | sed 's/^/-e /')))
+
+	rm -rf $(crds_gen_temp)
+	mkdir -p $(crds_gen_temp)
 
 	$(CONTROLLER-GEN) crd \
 		$(directories:%=paths=./%...) \
-		output:crd:artifacts:config=$(crds_dir)
+		output:crd:artifacts:config=$(crds_gen_temp)
 
-	echo "Updating CRDs with helm templating, writing to $(helm_chart_source_dir)/templates"
+	@echo "Updating CRDs with helm templating, writing to $(helm_chart_source_dir)/templates"
 
-	@for i in $$(basename $(crds_dir)/*.yaml); do \
-		crd_name=$$($(YQ) eval '.metadata.name' $(crds_dir)/$$i); \
+	@for i in $$(ls $(crds_gen_temp)); do \
+		crd_name=$$($(YQ) eval '.metadata.name' $(crds_gen_temp)/$$i); \
 		cat $(crd_template_header) > $(helm_chart_source_dir)/templates/crd-$$i; \
 		echo "" >> $(helm_chart_source_dir)/templates/crd-$$i; \
 		$(sed_inplace) "s/REPLACE_CRD_NAME/$$crd_name/g" $(helm_chart_source_dir)/templates/crd-$$i; \
 		$(sed_inplace) "s/REPLACE_LABELS_TEMPLATE/$(helm_labels_template_name)/g" $(helm_chart_source_dir)/templates/crd-$$i; \
-		$(YQ) -I2 '{"spec": .spec}' $(crds_dir)/$$i >> $(helm_chart_source_dir)/templates/crd-$$i; \
+		$(YQ) -I2 '{"spec": .spec}' $(crds_gen_temp)/$$i >> $(helm_chart_source_dir)/templates/crd-$$i; \
 		cat $(crd_template_footer) >> $(helm_chart_source_dir)/templates/crd-$$i; \
 	done
+
+	@if [ -n "$$(ls $(crds_gen_temp) 2>/dev/null)" ]; then \
+		cp -Tr $(crds_gen_temp) $(crds_dir); \
+		cp $(crds_dir_readme) $(crds_dir)/README.md; \
+	fi
 
 shared_generate_targets += generate-crds


### PR DESCRIPTION
Adds logic for pushing the Helm chart to an OCI registry (and adding a non-v-prefixed tag)

You can test the released OCI Helm chart here:
`helm install approver-policy oci://quay.io/jetstack/charts/cert-manager-approver-policy --version 0.18.0-alpha.0`
`helm install approver-policy oci://quay.io/jetstack/charts/cert-manager-approver-policy --version v0.18.0-alpha.0`

See https://github.com/cert-manager/makefile-modules/pull/219 for more info.