### PR TITLE
Add support for client-gen

### DIFF
--- a/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
+++ b/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
@@ -25,6 +25,7 @@ import (
 var CertificateRequestPolicyKind = "CertificateRequestPolicy"
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 //+kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type == "Ready")].status`,description="CertificateRequestPolicy is ready for evaluation"

--- a/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
+++ b/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
@@ -43,7 +43,6 @@ type CertificateRequestPolicy struct {
 	Status CertificateRequestPolicyStatus `json:"status,omitempty"`
 }
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // CertificateRequestPolicyList is a list of CertificateRequestPolicies.
 type CertificateRequestPolicyList struct {

--- a/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
+++ b/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
@@ -24,6 +24,7 @@ import (
 
 var CertificateRequestPolicyKind = "CertificateRequestPolicy"
 
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 //+kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type == "Ready")].status`,description="CertificateRequestPolicy is ready for evaluation"
@@ -42,6 +43,7 @@ type CertificateRequestPolicy struct {
 	Status CertificateRequestPolicyStatus `json:"status,omitempty"`
 }
 
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // CertificateRequestPolicyList is a list of CertificateRequestPolicies.
 type CertificateRequestPolicyList struct {


### PR DESCRIPTION
This tiny change adds support for the [kubernetes code-generator tool for API client generation](https://github.com/kubernetes/code-generator). This allows third party tools to generate a [client-go](https://github.com/kubernetes/client-go) style client for approver-policy resources.

Here's where a kube SIG example project is doing the same thing: https://github.com/kubernetes/sample-controller/blob/master/pkg/apis/samplecontroller/v1alpha1/types.go#L23