### PR TITLE
Fix private key algorithm constraint always erroring when set

### DIFF
--- a/pkg/internal/approver/constraints/evaluator.go
+++ b/pkg/internal/approver/constraints/evaluator.go
@@ -116,7 +116,7 @@ func decodePublicKey(pub interface{}) (cmapi.PrivateKeyAlgorithm, int, error) {
 	case *ecdsa.PublicKey:
 		return cmapi.ECDSAKeyAlgorithm, pubKey.Curve.Params().BitSize, nil
 
-	case *ed25519.PublicKey:
+	case ed25519.PublicKey:
 		return cmapi.Ed25519KeyAlgorithm, -1, nil
 
 	default:

--- a/pkg/internal/approver/constraints/evaluator_test.go
+++ b/pkg/internal/approver/constraints/evaluator_test.go
@@ -35,8 +35,9 @@ import (
 
 func Test_Evaluate(t *testing.T) {
 	var (
-		ecdsaAlg = cmapi.ECDSAKeyAlgorithm
-		rsaAlg   = cmapi.RSAKeyAlgorithm
+		ecdsaAlg   = cmapi.ECDSAKeyAlgorithm
+		ed25519Alg = cmapi.Ed25519KeyAlgorithm
+		rsaAlg     = cmapi.RSAKeyAlgorithm
 	)
 
 	tests := map[string]struct {
@@ -45,6 +46,17 @@ func Test_Evaluate(t *testing.T) {
 		expResponse approver.EvaluationResponse
 		expErr      bool
 	}{
+		"passes on Ed25519 CSR with private key constraints set": {
+			request: gen.CertificateRequest("", gen.SetCertificateRequestCSR(csrFrom(t, x509.Ed25519))),
+			policy: policyapi.CertificateRequestPolicySpec{
+				Constraints: &policyapi.CertificateRequestPolicyConstraints{
+					PrivateKey: &policyapi.CertificateRequestPolicyConstraintsPrivateKey{
+						Algorithm: &ed25519Alg,
+					},
+				},
+			},
+			expResponse: approver.EvaluationResponse{Result: approver.ResultNotDenied, Message: ""},
+		},
 		"if no constraints defined, should return NotDenied": {
 			request: gen.CertificateRequest("", gen.SetCertificateRequestCSR(csrFrom(t, x509.ECDSA))),
 			policy: policyapi.CertificateRequestPolicySpec{

--- a/pkg/internal/approver/constraints/evaluator_test.go
+++ b/pkg/internal/approver/constraints/evaluator_test.go
@@ -177,8 +177,8 @@ func Test_Evaluate(t *testing.T) {
 	}
 }
 
-func csrFrom(t *testing.T, keyAlgorithm x509.PublicKeyAlgorithm, mods ...gen.CSRModifier) []byte {
-	csr, _, err := gen.CSR(keyAlgorithm, mods...)
+func csrFrom(t *testing.T, keyAlgorithm x509.PublicKeyAlgorithm) []byte {
+	csr, _, err := gen.CSR(keyAlgorithm)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
It looks like the upstream golang crypto/x509 returns a `PublicKey` instance for ed25519 instead of a `PublicKey` pointer for some reason (see [here](https://cs.opensource.google/go/go/+/refs/tags/go1.23.5:src/crypto/x509/parser.go;l=282). As a result, constraint evaluation fails on all CRPs with a private key constraint being set, when the CSR being evaluated uses an ed25519 key.

This fixes the issue and adds a test to cover it.