### PR TITLE
Set container port names on Helm chart

### DIFF
--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -38,8 +38,12 @@ spec:
         image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.app.webhook.port }}
-        - containerPort: {{ .Values.app.metrics.port }}
+        - name: https
+          containerPort: {{ .Values.app.webhook.port }}
+        - name: http-metrics
+          containerPort: {{ .Values.app.metrics.port }}
+        - name: healthcheck
+          containerPort: {{ .Values.app.readinessProbe.port }}
         readinessProbe:
           httpGet:
             port: {{ .Values.app.readinessProbe.port }}

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -38,9 +38,9 @@ spec:
         image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-        - name: https
+        - name: webhook
           containerPort: {{ .Values.app.webhook.port }}
-        - name: http-metrics
+        - name: metrics
           containerPort: {{ .Values.app.metrics.port }}
         - name: healthcheck
           containerPort: {{ .Values.app.readinessProbe.port }}


### PR DESCRIPTION
Setting the container port names makes writing network policies a little easier. The set names match the port names that cert-manager uses.