### PR TITLE
Bump Go to 1.24 fixing new lint errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/approver-policy
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cert-manager/cert-manager v1.17.1

--- a/pkg/internal/approver/allowed/evaluator_test.go
+++ b/pkg/internal/approver/allowed/evaluator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package allowed
 
 import (
-	"context"
 	"crypto/x509"
 	"net"
 	"net/url"
@@ -460,7 +459,7 @@ func Test_Evaluate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			response, err := Approver().Evaluate(context.TODO(), &policyapi.CertificateRequestPolicy{Spec: test.policy}, test.request)
+			response, err := Approver().Evaluate(t.Context(), &policyapi.CertificateRequestPolicy{Spec: test.policy}, test.request)
 			assert.Equal(t, test.expErr, err != nil, "%v", err)
 			if diff := cmp.Diff(response, test.expResponse); diff != "" {
 				t.Errorf("unexpected evaluation response (-want +got):\n%v", diff)

--- a/pkg/internal/approver/allowed/validation_test.go
+++ b/pkg/internal/approver/allowed/validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package allowed
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -211,7 +210,7 @@ func Test_Validate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			response, err := Approver().Validate(context.TODO(), test.policy)
+			response, err := Approver().Validate(t.Context(), test.policy)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expResponse, response)
 		})

--- a/pkg/internal/approver/constraints/evaluator_test.go
+++ b/pkg/internal/approver/constraints/evaluator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package constraints
 
 import (
-	"context"
 	"crypto/x509"
 	"testing"
 	"time"
@@ -170,7 +169,7 @@ func Test_Evaluate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			response, err := Approver().Evaluate(context.TODO(), &policyapi.CertificateRequestPolicy{Spec: test.policy}, test.request)
+			response, err := Approver().Evaluate(t.Context(), &policyapi.CertificateRequestPolicy{Spec: test.policy}, test.request)
 			assert.Equal(t, test.expErr, err != nil, "%v", err)
 			assert.Equal(t, test.expResponse, response, "unexpected evaluation response")
 		})

--- a/pkg/internal/approver/constraints/validation_test.go
+++ b/pkg/internal/approver/constraints/validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package constraints
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -121,7 +120,7 @@ func Test_Validate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			response, err := Approver().Validate(context.TODO(), test.policy)
+			response, err := Approver().Validate(t.Context(), test.policy)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expResponse, response)
 		})

--- a/pkg/internal/controllers/certificaterequestpolicies_test.go
+++ b/pkg/internal/controllers/certificaterequestpolicies_test.go
@@ -447,7 +447,7 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 				reconcilers: test.reconcilers,
 			}
 
-			resp, statusPatch, err := c.reconcileStatusPatch(context.TODO(), ctrl.Request{NamespacedName: types.NamespacedName{Name: policyName}})
+			resp, statusPatch, err := c.reconcileStatusPatch(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: policyName}})
 			if (err != nil) != test.expError {
 				t.Errorf("unexpected error, exp=%t got=%v", test.expError, err)
 			}

--- a/pkg/internal/controllers/certificaterequests_test.go
+++ b/pkg/internal/controllers/certificaterequests_test.go
@@ -194,7 +194,7 @@ func Test_certificaterequests_Reconcile(t *testing.T) {
 				clock:    fixedclock,
 			}
 
-			resp, statusPatch, err := c.reconcileStatusPatch(context.TODO(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: gen.DefaultTestNamespace, Name: requestName}})
+			resp, statusPatch, err := c.reconcileStatusPatch(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Namespace: gen.DefaultTestNamespace, Name: requestName}})
 			if (err != nil) != test.expError {
 				t.Errorf("unexpected error, exp=%t got=%v", test.expError, err)
 			}

--- a/pkg/internal/controllers/test/controllers_test.go
+++ b/pkg/internal/controllers/test/controllers_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package test
 
 import (
-	"context"
 	"path"
 	"testing"
 
@@ -32,12 +31,7 @@ import (
 func Test_Controllers(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
-	ctx, cancel := context.WithCancel(context.TODO())
-	t.Cleanup(func() {
-		cancel()
-	})
-
-	env = testenv.RunControlPlane(t, ctx,
+	env = testenv.RunControlPlane(t, t.Context(),
 		testenv.GetenvOrFail(t, "CERT_MANAGER_CRDS"),
 		path.Join("..", "..", "..", "..", "deploy", "crds"),
 	)

--- a/pkg/internal/metrics/metrics_test.go
+++ b/pkg/internal/metrics/metrics_test.go
@@ -173,7 +173,7 @@ func Test_Metrics(t *testing.T) {
 func mockCollector(t *testing.T, crs []cmapi.CertificateRequest) *collector {
 	return &collector{
 		cache: &mockCache{t: t, objects: crs},
-		ctx:   context.Background(),
+		ctx:   t.Context(),
 		log:   logr.Discard(),
 	}
 }

--- a/pkg/internal/webhook/validator_test.go
+++ b/pkg/internal/webhook/validator_test.go
@@ -215,7 +215,7 @@ func Test_validate(t *testing.T) {
 				Build()
 
 			v := &validator{lister: fakeclient, log: ktesting.NewLogger(t, ktesting.DefaultConfig), webhooks: test.webhooks, registeredPlugins: test.registeredPlugins}
-			gotWarnings, gotErr := v.validate(context.Background(), test.crp)
+			gotWarnings, gotErr := v.validate(t.Context(), test.crp)
 			if test.expectedError == nil && gotErr != nil {
 				t.Errorf("unexpected error: %v", gotErr)
 			} else if test.expectedError != nil && (gotErr == nil || *test.expectedError != gotErr.Error()) {


### PR DESCRIPTION
In https://github.com/cert-manager/approver-policy/pull/622, we are forced to bump Go to 1.24, but that introduces new linter errors from the [`usetesting` linter](https://golangci-lint.run/usage/linters/#usetesting). Since this requires many changes, I think it's best to do it in a separate PR that is reviewed (by someone other than the commit author).