### PR TITLE
Remove use of deprecated c/r Result.Requeue

### DIFF
--- a/pkg/internal/controllers/certificaterequestpolicies.go
+++ b/pkg/internal/controllers/certificaterequestpolicies.go
@@ -195,11 +195,10 @@ func (c *certificaterequestpolicies) reconcileStatusPatch(ctx context.Context, r
 
 		// Capture requeue. If requeue is not currently set or the given
 		// requeueAfter is smaller than the current, set to given requeueAfter.
-		if response.Requeue || response.RequeueAfter > 0 {
-			if !result.Requeue || result.RequeueAfter > response.RequeueAfter {
+		if response.RequeueAfter > 0 {
+			if result.RequeueAfter == 0 || result.RequeueAfter > response.RequeueAfter {
 				result.RequeueAfter = response.RequeueAfter
 			}
-			result.Requeue = true
 		}
 
 		el = append(el, response.Errors...)

--- a/pkg/internal/controllers/certificaterequestpolicies_test.go
+++ b/pkg/internal/controllers/certificaterequestpolicies_test.go
@@ -143,37 +143,15 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expStatusPatch: nil,
 			expEvent:       "",
 		},
-		"if reconciler returns ready response with requeue, update to ready and mark requeue": {
-			existingObjects: []runtime.Object{&policyapi.CertificateRequestPolicy{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Generation: policyGeneration, ResourceVersion: "3"},
-				TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequestPolicy", APIVersion: "policy.cert-manager.io/v1alpha1"},
-			}},
-			reconcilers: []approver.Reconciler{fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-				return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{Requeue: true}}, nil
-			})},
-			expResult: ctrl.Result{Requeue: true},
-			expError:  false,
-			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
-						Status:             corev1.ConditionTrue,
-						LastTransitionTime: fixedmetatime,
-						Reason:             "Ready",
-						Message:            "CertificateRequestPolicy is ready for approval evaluation",
-						ObservedGeneration: policyGeneration},
-				},
-			},
-			expEvent: "Normal Ready CertificateRequestPolicy is ready for approval evaluation",
-		},
 		"if reconciler returns ready response with requeue and requeueAfter, update to ready and mark requeue with requeueAfter": {
 			existingObjects: []runtime.Object{&policyapi.CertificateRequestPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Generation: policyGeneration, ResourceVersion: "3"},
 				TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequestPolicy", APIVersion: "policy.cert-manager.io/v1alpha1"},
 			}},
 			reconcilers: []approver.Reconciler{fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-				return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Second}}, nil
+				return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{RequeueAfter: time.Second}}, nil
 			})},
-			expResult: ctrl.Result{Requeue: true, RequeueAfter: time.Second},
+			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
 				Conditions: []policyapi.CertificateRequestPolicyCondition{
@@ -193,9 +171,9 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 				TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequestPolicy", APIVersion: "policy.cert-manager.io/v1alpha1"},
 			}},
 			reconcilers: []approver.Reconciler{fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-				return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{Requeue: false, RequeueAfter: time.Second}}, nil
+				return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{RequeueAfter: time.Second}}, nil
 			})},
-			expResult: ctrl.Result{Requeue: true, RequeueAfter: time.Second},
+			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
 				Conditions: []policyapi.CertificateRequestPolicyCondition{
@@ -216,13 +194,13 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			}},
 			reconcilers: []approver.Reconciler{
 				fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-					return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Minute}}, nil
+					return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{RequeueAfter: time.Minute}}, nil
 				}),
 				fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-					return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Second}}, nil
+					return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{RequeueAfter: time.Second}}, nil
 				}),
 			},
-			expResult: ctrl.Result{Requeue: true, RequeueAfter: time.Second},
+			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
 				Conditions: []policyapi.CertificateRequestPolicyCondition{
@@ -250,9 +228,9 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 				}},
 			}},
 			reconcilers: []approver.Reconciler{fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-				return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Second}}, nil
+				return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{RequeueAfter: time.Second}}, nil
 			})},
-			expResult: ctrl.Result{Requeue: true, RequeueAfter: time.Second},
+			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
 				Conditions: []policyapi.CertificateRequestPolicyCondition{
@@ -280,9 +258,9 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 				}},
 			}},
 			reconcilers: []approver.Reconciler{fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-				return approver.ReconcilerReadyResponse{Ready: false, Errors: field.ErrorList{field.Forbidden(field.NewPath("foo"), "not allowed")}, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Second}}, nil
+				return approver.ReconcilerReadyResponse{Ready: false, Errors: field.ErrorList{field.Forbidden(field.NewPath("foo"), "not allowed")}, Result: ctrl.Result{RequeueAfter: time.Second}}, nil
 			})},
-			expResult: ctrl.Result{Requeue: true, RequeueAfter: time.Second},
+			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
 				Conditions: []policyapi.CertificateRequestPolicyCondition{
@@ -311,13 +289,13 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			}},
 			reconcilers: []approver.Reconciler{
 				fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-					return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Second}}, nil
+					return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{RequeueAfter: time.Second}}, nil
 				}),
 				fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
 					return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{}}, nil
 				}),
 			},
-			expResult: ctrl.Result{Requeue: true, RequeueAfter: time.Second},
+			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
 				Conditions: []policyapi.CertificateRequestPolicyCondition{
@@ -346,13 +324,13 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			}},
 			reconcilers: []approver.Reconciler{
 				fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-					return approver.ReconcilerReadyResponse{Ready: false, Errors: field.ErrorList{field.Forbidden(field.NewPath("foo"), "not allowed")}, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Second}}, nil
+					return approver.ReconcilerReadyResponse{Ready: false, Errors: field.ErrorList{field.Forbidden(field.NewPath("foo"), "not allowed")}, Result: ctrl.Result{RequeueAfter: time.Second}}, nil
 				}),
 				fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-					return approver.ReconcilerReadyResponse{Ready: false, Errors: field.ErrorList{field.Forbidden(field.NewPath("bar"), "also not allowed")}, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Second}}, nil
+					return approver.ReconcilerReadyResponse{Ready: false, Errors: field.ErrorList{field.Forbidden(field.NewPath("bar"), "also not allowed")}, Result: ctrl.Result{RequeueAfter: time.Second}}, nil
 				}),
 			},
-			expResult: ctrl.Result{Requeue: true, RequeueAfter: time.Second},
+			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
 				Conditions: []policyapi.CertificateRequestPolicyCondition{
@@ -381,13 +359,13 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			}},
 			reconcilers: []approver.Reconciler{
 				fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-					return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Second}}, nil
+					return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{RequeueAfter: time.Second}}, nil
 				}),
 				fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-					return approver.ReconcilerReadyResponse{Ready: false, Errors: field.ErrorList{field.Forbidden(field.NewPath("foo"), "not allowed")}, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Minute}}, nil
+					return approver.ReconcilerReadyResponse{Ready: false, Errors: field.ErrorList{field.Forbidden(field.NewPath("foo"), "not allowed")}, Result: ctrl.Result{RequeueAfter: time.Minute}}, nil
 				}),
 			},
-			expResult: ctrl.Result{Requeue: true, RequeueAfter: time.Second},
+			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
 				Conditions: []policyapi.CertificateRequestPolicyCondition{
@@ -416,7 +394,7 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			}},
 			reconcilers: []approver.Reconciler{
 				fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-					return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Second}}, nil
+					return approver.ReconcilerReadyResponse{Ready: true, Result: ctrl.Result{RequeueAfter: time.Second}}, nil
 				}),
 				fakeapprover.NewFakeReconciler().WithReady(func(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
 					return approver.ReconcilerReadyResponse{}, errors.New("this is an error")

--- a/pkg/internal/controllers/certificaterequests.go
+++ b/pkg/internal/controllers/certificaterequests.go
@@ -246,7 +246,7 @@ func (c *certificaterequests) reconcileStatusPatch(ctx context.Context, req ctrl
 		c.recorder.Event(cr, corev1.EventTypeWarning, "UnknownResponse", "Policy returned an unknown result. This is a bug. Please check the approver-policy logs and file an issue")
 
 		// We can do nothing but keep retrying the review here.
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil, nil
+		return ctrl.Result{RequeueAfter: time.Second * 5}, nil, nil
 
 	}
 }

--- a/pkg/internal/controllers/certificaterequests_test.go
+++ b/pkg/internal/controllers/certificaterequests_test.go
@@ -109,7 +109,7 @@ func Test_certificaterequests_Reconcile(t *testing.T) {
 			manager: fakemanager.NewFakeManager().WithReview(func(context.Context, *cmapi.CertificateRequest) (manager.ReviewResponse, error) {
 				return manager.ReviewResponse{}, nil
 			}),
-			expResult:      ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5},
+			expResult:      ctrl.Result{RequeueAfter: time.Second * 5},
 			expError:       false,
 			expStatusPatch: nil,
 			expEvent:       "Warning UnknownResponse Policy returned an unknown result. This is a bug. Please check the approver-policy logs and file an issue",
@@ -119,7 +119,7 @@ func Test_certificaterequests_Reconcile(t *testing.T) {
 			manager: fakemanager.NewFakeManager().WithReview(func(context.Context, *cmapi.CertificateRequest) (manager.ReviewResponse, error) {
 				return manager.ReviewResponse{Result: 5, Message: "unknown result"}, nil
 			}),
-			expResult:      ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5},
+			expResult:      ctrl.Result{RequeueAfter: time.Second * 5},
 			expError:       false,
 			expStatusPatch: nil,
 			expEvent:       "Warning UnknownResponse Policy returned an unknown result. This is a bug. Please check the approver-policy logs and file an issue",

--- a/pkg/internal/controllers/test/ready.go
+++ b/pkg/internal/controllers/test/ready.go
@@ -214,7 +214,7 @@ var _ = Context("Ready", func() {
 				return approver.ReconcilerReadyResponse{Ready: true}, nil
 			}
 			i++
-			return approver.ReconcilerReadyResponse{Ready: false, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Millisecond * 100}}, nil
+			return approver.ReconcilerReadyResponse{Ready: false, Result: ctrl.Result{RequeueAfter: time.Millisecond * 100}}, nil
 		})
 
 		plugin3.FakeReconciler = fake.NewFakeReconciler().WithReady(func(_ context.Context, policy *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {

--- a/pkg/internal/controllers/test/selector.go
+++ b/pkg/internal/controllers/test/selector.go
@@ -235,7 +235,7 @@ var _ = Context("Selector", func() {
 
 	It("it should not select on CertificateRequests where the IssuerRef matches but the policy is not ready", func() {
 		plugin.FakeReconciler = fake.NewFakeReconciler().WithReady(func(_ context.Context, policy *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-			return approver.ReconcilerReadyResponse{Ready: false, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Millisecond * 50}}, nil
+			return approver.ReconcilerReadyResponse{Ready: false, Result: ctrl.Result{RequeueAfter: time.Millisecond * 50}}, nil
 		})
 		policy := policyapi.CertificateRequestPolicy{
 			ObjectMeta: metav1.ObjectMeta{GenerateName: "allow-all"},
@@ -612,7 +612,7 @@ var _ = Context("Selector", func() {
 
 	It("it should not select on CertificateRequests where the namespace matches but the policy is not ready", func() {
 		plugin.FakeReconciler = fake.NewFakeReconciler().WithReady(func(_ context.Context, policy *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-			return approver.ReconcilerReadyResponse{Ready: false, Result: ctrl.Result{Requeue: true, RequeueAfter: time.Millisecond * 50}}, nil
+			return approver.ReconcilerReadyResponse{Ready: false, Result: ctrl.Result{RequeueAfter: time.Millisecond * 50}}, nil
 		})
 
 		policy := policyapi.CertificateRequestPolicy{


### PR DESCRIPTION
The field `Result.Requeue` is deprecated in controller-runtime 0.21.0, and I don't know why we are using it at all - since the Godoc of `Result.RequeueAfter` states:

> // RequeueAfter if greater than 0, tells the Controller to requeue the reconcile key after the Duration.
> // Implies that Requeue is true, there is no need to set Requeue to true at the same time as RequeueAfter.

Blocks https://github.com/cert-manager/approver-policy/pull/640.