### PR TITLE
Add new certificaterequests_approval metric

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,10 +4,6 @@ linters:
   exclusions:
     generated: lax
     presets: [comments, common-false-positives, legacy, std-error-handling]
-    rules:
-      - linters:
-          - promlinter
-        text: .*
     paths: [third_party, builtin$, examples$]
     warn-unused: true
   settings:

--- a/pkg/internal/cmd/cmd.go
+++ b/pkg/internal/cmd/cmd.go
@@ -104,7 +104,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			metrics.RegisterMetrics(ctx, opts.Logr.WithName("metrics"), mgr.GetCache())
+			metrics.RegisterMetrics(ctx, opts.Logr.WithName("metrics"), mgr.GetClient())
 
 			if err := webhook.Register(ctx, webhook.Options{
 				Log:      opts.Logr,

--- a/pkg/internal/metrics/metrics.go
+++ b/pkg/internal/metrics/metrics.go
@@ -18,17 +18,38 @@ package metrics
 
 import (
 	"context"
-	"time"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var (
+	// certificateRequestsApproval reports the number of CertificateRequest resources
+	// with approver-policy conditions set.
+	//
+	// It is a GaugeVec with the following labels:
+	//   - "namespace": the namespace of the CertificateRequest.
+	//   - "status": the approval status of the CertificateRequest.
+	//     Possible values are:
+	//       * "approved"    — the CertificateRequest has been approved.
+	//       * "denied"      — the CertificateRequest has been denied.
+	//       * "unmatched"   — the CertificateRequest not matched by any approvers.
+	//
+	// Exposed as the metric `certmanager_approverpolicy_certificaterequests_approval`.
+	certificateRequestsApproval = prometheus.NewDesc(
+		"certmanager_approverpolicy_certificaterequests_approval",
+		"The approval status of CertificateRequests. Possible values for the 'status' label: 'approved', 'denied', 'unmatched'.",
+		[]string{
+			"namespace",
+			"status",
+		},
+		nil,
+	)
+
 	// approvedCount counts the number of CertificateRequest currently approved
 	// or denied by looking at the Approved condition. For context, the Approved
 	// condition looks like this:
@@ -43,7 +64,7 @@ var (
 	// get removed over time e.g. with revisionHistoryLimit.
 	approvedCount = prometheus.NewDesc(
 		"approverpolicy_certificaterequest_approved_count",
-		"Number of CertificateRequests that have been approved (Approved=True).",
+		"DEPRECATED: use certmanager_approverpolicy_certificaterequests_approval instead. Number of CertificateRequests that have been approved (Approved=True).",
 		[]string{
 			"namespace",
 		},
@@ -60,7 +81,7 @@ var (
 	//     Invalid value: []string{"forbidden-domain-41.com"}: *.example.com, *.ca-wont-accept.org]'
 	deniedCount = prometheus.NewDesc(
 		"approverpolicy_certificaterequest_denied_count",
-		"Number of CertificateRequests that have been denied (Denied=True).",
+		"DEPRECATED: use certmanager_approverpolicy_certificaterequests_approval instead. Number of CertificateRequests that have been denied (Denied=True).",
 		[]string{
 			"namespace",
 		},
@@ -73,7 +94,7 @@ var (
 	// condition.
 	unmatchedCount = prometheus.NewDesc(
 		"approverpolicy_certificaterequest_unmatched_count",
-		"Number of CertificateRequests not matched to any policy, i.e., that don't have an Approved or Denied condition set yet.",
+		"DEPRECATED: use certmanager_approverpolicy_certificaterequests_approval instead. Number of CertificateRequests not matched to any policy, i.e., that don't have an Approved or Denied condition set yet.",
 		[]string{
 			"namespace",
 		},
@@ -83,17 +104,17 @@ var (
 
 // You don't need to wait for the cache to be synced before calling this. This
 // function is non-blocking.
-func RegisterMetrics(ctx context.Context, log logr.Logger, c cache.Cache) {
-	metrics.Registry.MustRegister(collector{ctx, log, c})
+func RegisterMetrics(ctx context.Context, log logr.Logger, r client.Reader) {
+	metrics.Registry.MustRegister(collector{ctx, log, r})
 }
 
 // We use a custom collector instead of prometheus.NewGaugeVec because it is
 // much easier to list all of the certificate requests when the `/metrics`
 // endpoint is hit rather than using a controller-runtime reconciler.
 type collector struct {
-	ctx   context.Context
-	log   logr.Logger
-	cache cache.Cache
+	ctx    context.Context
+	log    logr.Logger
+	reader client.Reader
 }
 
 func (cc collector) Describe(ch chan<- *prometheus.Desc) {
@@ -101,35 +122,61 @@ func (cc collector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (cc collector) Collect(ch chan<- prometheus.Metric) {
-	// We found a niche problem where `/metrics` would hang forever in case of a
-	// misconfigured RBAC. This was due to `cache.List` hanging until the cache
-	// is synced. To prevent that, we skip reporting this subset of the metrics.
-	if !hasSynced(cc.cache) {
-		cc.log.Info("cache not synced yet, skipping metrics approverpolicy_certificaterequest_*")
+	collectCertificateRequestsApproval(cc.ctx, cc.log, cc.reader, ch)
+	collectCRsApproved(cc.ctx, cc.log, cc.reader, ch)
+	collectCRsDenied(cc.ctx, cc.log, cc.reader, ch)
+	collectCRsUnmatched(cc.ctx, cc.log, cc.reader, ch)
+}
+
+func collectCertificateRequestsApproval(ctx context.Context, log logr.Logger, r client.Reader, ch chan<- prometheus.Metric) {
+	list := &cmapi.CertificateRequestList{}
+	err := r.List(ctx, list)
+	if err != nil {
+		log.Error(err, "unable to list CertificateRequests")
 		return
 	}
 
-	collectCRsApproved(cc.ctx, cc.log, cc.cache, ch)
-	collectCRsDenied(cc.ctx, cc.log, cc.cache, ch)
-	collectCRsUnmatched(cc.log, cc.cache, ch)
+	type label struct {
+		namespace string
+		status    string
+	}
+
+	// Let's remember the order of the labels so that we can send the metrics
+	// deterministically. Undeterministic outputs are a pain to test and debug.
+	var labels []label
+	count := make(map[label]int)
+
+	for _, cr := range list.Items {
+		status := "unmatched"
+		switch {
+		case isStatusConditionTrue(cr.Status.Conditions, cmapi.CertificateRequestConditionApproved):
+			status = "approved"
+		case isStatusConditionTrue(cr.Status.Conditions, cmapi.CertificateRequestConditionDenied):
+			status = "denied"
+		}
+
+		k := label{namespace: cr.Namespace, status: status}
+		_, exists := count[k]
+		if !exists {
+			labels = append(labels, k)
+		}
+		count[k]++
+	}
+
+	for _, key := range labels {
+		ch <- prometheus.MustNewConstMetric(
+			certificateRequestsApproval,
+			prometheus.GaugeValue,
+			float64(count[key]),
+			key.namespace,
+			key.status,
+		)
+	}
 }
 
-// hasSynced returns true if the cache has synced. Otherwise, it returns false.
-// It is non-blocking.
-func hasSynced(cache cache.Cache) bool {
-	// Why tempCtx? Controller-runtime doesn't give us a non-blocking way to
-	// know if the cache is in sync. The only way it to use `WaitForCacheSync`,
-	// but that's a blocking operation. 10 milliseconds seems like plenty enough
-	// time since `WaitForCacheSync` doesn't do any network call to know if the
-	// cache is ready.
-	tempCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	defer cancel()
-	return cache.WaitForCacheSync(tempCtx)
-}
-
-func collectCRsApproved(ctx context.Context, log logr.Logger, c cache.Cache, ch chan<- prometheus.Metric) {
+func collectCRsApproved(ctx context.Context, log logr.Logger, r client.Reader, ch chan<- prometheus.Metric) {
 	list := &cmapi.CertificateRequestList{}
-	err := c.List(ctx, list)
+	err := r.List(ctx, list)
 	if err != nil {
 		log.Error(err, "unable to list CertificateRequests")
 		return
@@ -145,8 +192,7 @@ func collectCRsApproved(ctx context.Context, log logr.Logger, c cache.Cache, ch 
 	for _, cr := range list.Items {
 		// A certificate request is said to be approved if it has the condition
 		// Approved=True.
-		approvedStatus := getStatus(cmapi.CertificateRequestConditionApproved, cr.Status.Conditions)
-		if approvedStatus != "True" {
+		if !isStatusConditionTrue(cr.Status.Conditions, cmapi.CertificateRequestConditionApproved) {
 			continue
 		}
 
@@ -155,10 +201,11 @@ func collectCRsApproved(ctx context.Context, log logr.Logger, c cache.Cache, ch 
 		if !exists {
 			labels = append(labels, k)
 		}
-		count[k] += 1
+		count[k]++
 	}
 
 	for _, key := range labels {
+		//nolint:promlinter // This metric is deprecated and will eventually be removed, https://github.com/cert-manager/approver-policy/issues/713.
 		ch <- prometheus.MustNewConstMetric(
 			approvedCount,
 			prometheus.GaugeValue,
@@ -168,9 +215,9 @@ func collectCRsApproved(ctx context.Context, log logr.Logger, c cache.Cache, ch 
 	}
 }
 
-func collectCRsDenied(ctx context.Context, log logr.Logger, c cache.Cache, ch chan<- prometheus.Metric) {
+func collectCRsDenied(ctx context.Context, log logr.Logger, r client.Reader, ch chan<- prometheus.Metric) {
 	list := &cmapi.CertificateRequestList{}
-	err := c.List(ctx, list)
+	err := r.List(ctx, list)
 	if err != nil {
 		log.Error(err, "unable to list CertificateRequests")
 		return
@@ -182,10 +229,9 @@ func collectCRsDenied(ctx context.Context, log logr.Logger, c cache.Cache, ch ch
 	count := make(map[label]int)
 
 	for _, cr := range list.Items {
-		deniedStatus := getStatus(cmapi.CertificateRequestConditionDenied, cr.Status.Conditions)
 		// A certificate request is said to be denied if it has the condition
 		// Denied=True.
-		if deniedStatus != "True" {
+		if !isStatusConditionTrue(cr.Status.Conditions, cmapi.CertificateRequestConditionDenied) {
 			continue
 		}
 
@@ -194,10 +240,11 @@ func collectCRsDenied(ctx context.Context, log logr.Logger, c cache.Cache, ch ch
 		if !exists {
 			labels = append(labels, k)
 		}
-		count[k] += 1
+		count[k]++
 	}
 
 	for _, key := range labels {
+		//nolint:promlinter // This metric is deprecated and will eventually be removed, https://github.com/cert-manager/approver-policy/issues/713.
 		ch <- prometheus.MustNewConstMetric(
 			deniedCount,
 			prometheus.GaugeValue,
@@ -207,9 +254,9 @@ func collectCRsDenied(ctx context.Context, log logr.Logger, c cache.Cache, ch ch
 	}
 }
 
-func collectCRsUnmatched(logger logr.Logger, c cache.Cache, ch chan<- prometheus.Metric) {
+func collectCRsUnmatched(ctx context.Context, logger logr.Logger, r client.Reader, ch chan<- prometheus.Metric) {
 	list := &cmapi.CertificateRequestList{}
-	err := c.List(context.Background(), list)
+	err := r.List(ctx, list)
 	if err != nil {
 		logger.Error(err, "unable to list CertificateRequests")
 		return
@@ -225,9 +272,7 @@ func collectCRsUnmatched(logger logr.Logger, c cache.Cache, ch chan<- prometheus
 	for _, cr := range list.Items {
 		// A certificate request is said to be unmatched if it doesn't have the
 		// Approved and Denied conditions.
-		approvedStatus := getStatus(cmapi.CertificateRequestConditionApproved, cr.Status.Conditions)
-		deniedStatus := getStatus(cmapi.CertificateRequestConditionDenied, cr.Status.Conditions)
-		if approvedStatus == "True" || deniedStatus == "True" {
+		if isStatusConditionTrue(cr.Status.Conditions, cmapi.CertificateRequestConditionApproved) || isStatusConditionTrue(cr.Status.Conditions, cmapi.CertificateRequestConditionDenied) {
 			continue
 		}
 
@@ -236,10 +281,11 @@ func collectCRsUnmatched(logger logr.Logger, c cache.Cache, ch chan<- prometheus
 		if !exists {
 			labels = append(labels, k)
 		}
-		count[k] += 1
+		count[k]++
 	}
 
 	for _, key := range labels {
+		//nolint:promlinter // This metric is deprecated and will eventually be removed, ref. https://github.com/cert-manager/approver-policy/issues/713.
 		ch <- prometheus.MustNewConstMetric(
 			unmatchedCount,
 			prometheus.GaugeValue,
@@ -249,14 +295,12 @@ func collectCRsUnmatched(logger logr.Logger, c cache.Cache, ch chan<- prometheus
 	}
 }
 
-// Returns "True" or "False", or "Unknown" if the condition with the given type
-// (e.g., "Approved" or "Denied") exists, or "" if the condition is not found.
-func getStatus(condTyp cmapi.CertificateRequestConditionType, conditions []cmapi.CertificateRequestCondition) cmmeta.ConditionStatus {
-	for _, cond := range conditions {
-		if cond.Type == condTyp {
-			return cond.Status
+// isStatusConditionTrue returns true when the conditionType is present and status set to `True`.
+func isStatusConditionTrue(conditions []cmapi.CertificateRequestCondition, conditionType cmapi.CertificateRequestConditionType) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == cmmeta.ConditionTrue
 		}
 	}
-
-	return cmmeta.ConditionUnknown
+	return false
 }


### PR DESCRIPTION
The golangci-lint exclusion configuration triggered this change; instead of just adding the lint suppressions, I attempted to determine how these metrics could be made more useful for users.

Since the existing metrics don't follow best practices for naming metrics, I propose to deprecate them with a replacement.

For the replacement, I think it's more natural to have a single gauge metric with a label indicating if the CR is approved, denied, or unmatched.

I have also removed the explicit use of the c/r Cache, and instead use the c/r cached client, as this simplifies the code to a great deal. If this change is accepted, we should probably refactor the test code a bit more, but I didn't want to change the tests too much in this PR - to make it easier reviewable.