### PR TITLE
Finalize replacement of CertificateRequestPolicyCondition with metav1.Condition

### DIFF
--- a/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
+++ b/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
@@ -412,18 +412,14 @@ type CertificateRequestPolicyStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []CertificateRequestPolicyCondition `json:"conditions,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// CertificateRequestPolicyCondition contains condition information for a
-// CertificateRequestPolicyStatus.
-type CertificateRequestPolicyCondition = metav1.Condition
-
 const (
-	// CertificateRequestPolicyConditionReady indicates that the
+	// ConditionTypeReady indicates that the
 	// CertificateRequestPolicy has successfully loaded the policy, and all
 	// configuration including plugin options are accepted and ready for
 	// evaluating CertificateRequests.
 	// +k8s:deepcopy-gen=false
-	CertificateRequestPolicyConditionReady string = "Ready"
+	ConditionTypeReady string = "Ready"
 )

--- a/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
@@ -469,7 +469,7 @@ func (in *CertificateRequestPolicyStatus) DeepCopyInto(out *CertificateRequestPo
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]CertificateRequestPolicyCondition, len(*in))
+		*out = make([]metav1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/internal/approver/manager/predicate/predicate.go
+++ b/pkg/internal/approver/manager/predicate/predicate.go
@@ -44,7 +44,7 @@ func Ready(_ context.Context, _ *cmapi.CertificateRequest, policies []policyapi.
 
 	for _, policy := range policies {
 		for _, condition := range policy.Status.Conditions {
-			if condition.Type == policyapi.CertificateRequestPolicyConditionReady && condition.Status == metav1.ConditionTrue {
+			if condition.Type == policyapi.ConditionTypeReady && condition.Status == metav1.ConditionTrue {
 				readyPolicies = append(readyPolicies, policy)
 			}
 		}

--- a/pkg/internal/approver/manager/predicate/predicate_test.go
+++ b/pkg/internal/approver/manager/predicate/predicate_test.go
@@ -425,68 +425,68 @@ func Test_Ready(t *testing.T) {
 		},
 		"single policy with ready condition false should return no policies": {
 			policies: []policyapi.CertificateRequestPolicy{
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionFalse},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionFalse},
 				}}},
 			},
 			expPolicies: nil,
 		},
 		"single policy with ready condition true should return policy": {
 			policies: []policyapi.CertificateRequestPolicy{
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionTrue},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionTrue},
 				}}},
 			},
 			expPolicies: []policyapi.CertificateRequestPolicy{
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionTrue},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionTrue},
 				}}},
 			},
 		},
 		"one policy which is ready another not, return single policy": {
 			policies: []policyapi.CertificateRequestPolicy{
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionFalse},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionFalse},
 				}}},
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionTrue},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionTrue},
 				}}},
 			},
 			expPolicies: []policyapi.CertificateRequestPolicy{
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionTrue},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionTrue},
 				}}},
 			},
 		},
 		"mix of different conditions including ready should return only ready policies": {
 			policies: []policyapi.CertificateRequestPolicy{
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionFalse},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionFalse},
 					{Type: "C", Status: metav1.ConditionTrue},
 				}}},
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionTrue},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionTrue},
 					{Type: "B", Status: metav1.ConditionTrue},
 				}}},
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionTrue},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionTrue},
 					{Type: "A", Status: metav1.ConditionTrue},
 				}}},
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionTrue},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionTrue},
 				}}},
 			},
 			expPolicies: []policyapi.CertificateRequestPolicy{
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionTrue},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionTrue},
 					{Type: "B", Status: metav1.ConditionTrue},
 				}}},
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionTrue},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionTrue},
 					{Type: "A", Status: metav1.ConditionTrue},
 				}}},
-				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady, Status: metav1.ConditionTrue},
+				{Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady, Status: metav1.ConditionTrue},
 				}}},
 			},
 		},

--- a/pkg/internal/controllers/certificaterequestpolicies_test.go
+++ b/pkg/internal/controllers/certificaterequestpolicies_test.go
@@ -74,8 +74,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expResult: ctrl.Result{},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Ready",
@@ -96,8 +96,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expResult: ctrl.Result{},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Ready",
@@ -118,8 +118,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expResult: ctrl.Result{},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "NotReady",
@@ -153,8 +153,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Ready",
@@ -175,8 +175,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Ready",
@@ -202,8 +202,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Ready",
@@ -217,8 +217,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			existingObjects: []runtime.Object{&policyapi.CertificateRequestPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Generation: policyGeneration, ResourceVersion: "3"},
 				TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequestPolicy", APIVersion: "policy.cert-manager.io/v1alpha1"},
-				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Ready",
@@ -232,8 +232,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Ready",
@@ -247,8 +247,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			existingObjects: []runtime.Object{&policyapi.CertificateRequestPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Generation: policyGeneration, ResourceVersion: "3"},
 				TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequestPolicy", APIVersion: "policy.cert-manager.io/v1alpha1"},
-				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "NotReady",
@@ -262,8 +262,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "NotReady",
@@ -277,8 +277,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			existingObjects: []runtime.Object{&policyapi.CertificateRequestPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Generation: policyGeneration, ResourceVersion: "3"},
 				TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequestPolicy", APIVersion: "policy.cert-manager.io/v1alpha1"},
-				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Ready",
@@ -297,8 +297,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Ready",
@@ -312,8 +312,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			existingObjects: []runtime.Object{&policyapi.CertificateRequestPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Generation: policyGeneration, ResourceVersion: "3"},
 				TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequestPolicy", APIVersion: "policy.cert-manager.io/v1alpha1"},
-				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "NotReady",
@@ -332,8 +332,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "NotReady",
@@ -347,8 +347,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			existingObjects: []runtime.Object{&policyapi.CertificateRequestPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Generation: policyGeneration, ResourceVersion: "3"},
 				TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequestPolicy", APIVersion: "policy.cert-manager.io/v1alpha1"},
-				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "NotReady",
@@ -367,8 +367,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			expResult: ctrl.Result{RequeueAfter: time.Second},
 			expError:  false,
 			expStatusPatch: &policyapi.CertificateRequestPolicyStatus{
-				Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "NotReady",
@@ -382,8 +382,8 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 			existingObjects: []runtime.Object{&policyapi.CertificateRequestPolicy{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-policy", Generation: policyGeneration, ResourceVersion: "3"},
 				TypeMeta:   metav1.TypeMeta{Kind: "CertificateRequestPolicy", APIVersion: "policy.cert-manager.io/v1alpha1"},
-				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []policyapi.CertificateRequestPolicyCondition{
-					{Type: policyapi.CertificateRequestPolicyConditionReady,
+				Status: policyapi.CertificateRequestPolicyStatus{Conditions: []metav1.Condition{
+					{Type: policyapi.ConditionTypeReady,
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "NotReady",
@@ -449,7 +449,7 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 	}
 }
 
-func Test_certificaterequestpolicies_setCertificateRequestPolicyCondition(t *testing.T) {
+func Test_certificaterequestpolicies_setCondition(t *testing.T) {
 	const policyGeneration int64 = 2
 
 	var (
@@ -459,20 +459,20 @@ func Test_certificaterequestpolicies_setCertificateRequestPolicyCondition(t *tes
 	)
 
 	tests := map[string]struct {
-		existingConditions []policyapi.CertificateRequestPolicyCondition
-		patchConditions    []policyapi.CertificateRequestPolicyCondition
-		newCondition       policyapi.CertificateRequestPolicyCondition
-		expectedConditions []policyapi.CertificateRequestPolicyCondition
+		existingConditions []metav1.Condition
+		patchConditions    []metav1.Condition
+		newCondition       metav1.Condition
+		expectedConditions []metav1.Condition
 	}{
 		"no existing conditions should add the condition with time and gen to the policy": {
-			existingConditions: []policyapi.CertificateRequestPolicyCondition{},
-			newCondition: policyapi.CertificateRequestPolicyCondition{
+			existingConditions: []metav1.Condition{},
+			newCondition: metav1.Condition{
 				Type:    "A",
 				Status:  metav1.ConditionTrue,
 				Reason:  "B",
 				Message: "C",
 			},
-			expectedConditions: []policyapi.CertificateRequestPolicyCondition{{
+			expectedConditions: []metav1.Condition{{
 				Type:               "A",
 				Status:             metav1.ConditionTrue,
 				Reason:             "B",
@@ -482,14 +482,14 @@ func Test_certificaterequestpolicies_setCertificateRequestPolicyCondition(t *tes
 			}},
 		},
 		"an existing patch condition of different type should add a different condition with time and gen to the policy": {
-			patchConditions: []policyapi.CertificateRequestPolicyCondition{{Type: "B"}},
-			newCondition: policyapi.CertificateRequestPolicyCondition{
+			patchConditions: []metav1.Condition{{Type: "B"}},
+			newCondition: metav1.Condition{
 				Type:    "A",
 				Status:  metav1.ConditionTrue,
 				Reason:  "B",
 				Message: "C",
 			},
-			expectedConditions: []policyapi.CertificateRequestPolicyCondition{
+			expectedConditions: []metav1.Condition{
 				{Type: "B"},
 				{
 					Type:               "A",
@@ -502,7 +502,7 @@ func Test_certificaterequestpolicies_setCertificateRequestPolicyCondition(t *tes
 			},
 		},
 		"an existing patch condition of the same type but different status should be replaced with new time if it has a different status": {
-			patchConditions: []policyapi.CertificateRequestPolicyCondition{
+			patchConditions: []metav1.Condition{
 				{Type: "B"},
 				{
 					Type:               "A",
@@ -513,13 +513,13 @@ func Test_certificaterequestpolicies_setCertificateRequestPolicyCondition(t *tes
 					ObservedGeneration: policyGeneration - 1,
 				},
 			},
-			newCondition: policyapi.CertificateRequestPolicyCondition{
+			newCondition: metav1.Condition{
 				Type:    "A",
 				Status:  metav1.ConditionTrue,
 				Reason:  "B",
 				Message: "C",
 			},
-			expectedConditions: []policyapi.CertificateRequestPolicyCondition{
+			expectedConditions: []metav1.Condition{
 				{Type: "B"},
 				{
 					Type:               "A",
@@ -532,7 +532,7 @@ func Test_certificaterequestpolicies_setCertificateRequestPolicyCondition(t *tes
 			},
 		},
 		"an existing patch condition of the same type and status should be replaced with same time": {
-			patchConditions: []policyapi.CertificateRequestPolicyCondition{
+			patchConditions: []metav1.Condition{
 				{Type: "B"},
 				{
 					Type:               "A",
@@ -543,13 +543,13 @@ func Test_certificaterequestpolicies_setCertificateRequestPolicyCondition(t *tes
 					ObservedGeneration: policyGeneration - 1,
 				},
 			},
-			newCondition: policyapi.CertificateRequestPolicyCondition{
+			newCondition: metav1.Condition{
 				Type:    "A",
 				Status:  metav1.ConditionTrue,
 				Reason:  "B",
 				Message: "C",
 			},
-			expectedConditions: []policyapi.CertificateRequestPolicyCondition{
+			expectedConditions: []metav1.Condition{
 				{Type: "B"},
 				{
 					Type:               "A",
@@ -566,7 +566,7 @@ func Test_certificaterequestpolicies_setCertificateRequestPolicyCondition(t *tes
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := &certificaterequestpolicies{clock: fixedclock}
-			c.setCertificateRequestPolicyCondition(
+			c.setCondition(
 				test.existingConditions,
 				&test.patchConditions, // #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
 				policyGeneration,

--- a/pkg/internal/controllers/test/ready.go
+++ b/pkg/internal/controllers/test/ready.go
@@ -355,7 +355,7 @@ var _ = Context("Ready", func() {
 				if condition.ObservedGeneration != policy.Generation {
 					return true
 				}
-				if condition.Type == policyapi.CertificateRequestPolicyConditionReady && condition.Status == metav1.ConditionTrue {
+				if condition.Type == policyapi.ConditionTypeReady && condition.Status == metav1.ConditionTrue {
 					return true
 				}
 			}

--- a/pkg/internal/controllers/test/util.go
+++ b/pkg/internal/controllers/test/util.go
@@ -94,7 +94,7 @@ func waitForReady(ctx context.Context, cl client.Client, name string) {
 			if condition.ObservedGeneration != policy.Generation {
 				return false
 			}
-			if condition.Type == policyapi.CertificateRequestPolicyConditionReady && condition.Status == metav1.ConditionTrue {
+			if condition.Type == policyapi.ConditionTypeReady && condition.Status == metav1.ConditionTrue {
 				return true
 			}
 		}
@@ -115,7 +115,7 @@ func waitForNotReady(ctx context.Context, cl client.Client, name string) {
 			if condition.ObservedGeneration != policy.Generation {
 				return false
 			}
-			if condition.Type == policyapi.CertificateRequestPolicyConditionReady && condition.Status == metav1.ConditionFalse {
+			if condition.Type == policyapi.ConditionTypeReady && condition.Status == metav1.ConditionFalse {
 				return true
 			}
 		}

--- a/test/smoke/tests.go
+++ b/test/smoke/tests.go
@@ -102,7 +102,7 @@ var _ = Describe("Policy", func() {
 		Eventually(func() bool {
 			Expect(cl.Get(ctx, client.ObjectKey{Name: policy.Name}, &policy)).To(Succeed())
 			for _, condition := range policy.Status.Conditions {
-				if condition.Type == policyapi.CertificateRequestPolicyConditionReady {
+				if condition.Type == policyapi.ConditionTypeReady {
 					return condition.Status == metav1.ConditionTrue && condition.ObservedGeneration == policy.Generation
 				}
 			}


### PR DESCRIPTION
This PR is a follow-up to https://github.com/cert-manager/approver-policy/pull/746, which removes the aliased type and renames a condition type constant.