### PR TITLE
Use correct Renovate preset config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
-    'github>cert-manager/renovate-config:default.json5',
+    'github>cert-manager/makefile-modules:renovate-config.json5',
   ],
 }


### PR DESCRIPTION
It seems like we are not using the correct makefile-modules preset. This should at least fix the outdated licence file in https://github.com/cert-manager/approver-policy/pull/796.