### PR TITLE
Update OWNERS to use OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,21 +1,4 @@
 approvers:
-- munnerz
-- joshvanl
-- wallrj
-- jakexks
-- maelvls
-- irbekrm
-- sgtcodfish
-- inteon
-- erikgb
+- cm-maintainers
 reviewers:
-- munnerz
-- joshvanl
-- wallrj
-- jakexks
-- maelvls
-- irbekrm
-- sgtcodfish
-- inteon
-- erikgb
-- thatsmrtalbot
+- cm-maintainers


### PR DESCRIPTION
I noticed this bug when @ThatsMrTalbot attempted to approve https://github.com/cert-manager/approver-policy/pull/801, but it didn't count.