### PR TITLE
Grant missing RBAC to old events API group

### DIFF
--- a/deploy/charts/approver-policy/templates/clusterrole.yaml
+++ b/deploy/charts/approver-policy/templates/clusterrole.yaml
@@ -35,7 +35,7 @@ rules:
   resources: ["roles", "clusterroles", "rolebindings", "clusterrolebindings"]
   verbs: ["list", "watch"]
 
-- apiGroups: ["events.k8s.io"]
+- apiGroups: ["", "events.k8s.io"]
   resources: ["events"]
   verbs: ["create", "patch"]
 


### PR DESCRIPTION
Similar to https://github.com/cert-manager/trust-manager/pull/889. @wallrj noted that leader election events are stuck on the old events API group for now.