### PR TITLE
Don't mutate Helm values.yaml before a release

### DIFF
--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -38,8 +38,5 @@ helm_labels_template_name := cert-manager-approver-policy.labels
 golangci_lint_config := .golangci.yaml
 
 define helm_values_mutation_function
-$(YQ) \
-	'( .image.repository = "$(oci_manager_image_name)" ) | \
-	( .image.tag = "$(oci_manager_image_tag)" )' \
-	$1 --inplace
+echo "OK: nothing to mutate in Helm values"
 endef


### PR DESCRIPTION
We use `$.Chart.AppVersion` instead of injecting a tag in the values.yaml file now.
Also, we use the `.imageRegistry` and `.imageNamespace` now to construct the image path instead of using `image.repository` by default.

We forgot to add this to https://github.com/cert-manager/approver-policy/pull/814