### PR TITLE
Fix race condition with default deny and approving policies

### DIFF
--- a/pkg/internal/approver/manager/review.go
+++ b/pkg/internal/approver/manager/review.go
@@ -37,9 +37,10 @@ var _ manager.Interface = &mngr{}
 // filtering CertificiateRequestPolicies based on predicates, and evaluating
 // CertificateRequests using the registered evaluators.
 type mngr struct {
-	lister     client.Reader
-	predicates []predicate.Predicate
-	evaluators []approver.Evaluator
+	lister         client.Reader
+	readyPredicate predicate.Predicate
+	predicates     []predicate.Predicate
+	evaluators     []approver.Evaluator
 }
 
 // policyMessage holds the name of the CertificateRequestPolicy and aggregated
@@ -66,9 +67,9 @@ type policyMessage struct {
 //     CertificateRequest
 func New(lister client.Reader, client client.Client, evaluators []approver.Evaluator) manager.Interface {
 	return &mngr{
-		lister: lister,
+		lister:         lister,
+		readyPredicate: predicate.Ready,
 		predicates: []predicate.Predicate{
-			predicate.Ready,
 			predicate.SelectorIssuerRef,
 			predicate.SelectorNamespace(lister),
 			predicate.RBACBound(client),
@@ -97,11 +98,23 @@ func (m *mngr) Review(ctx context.Context, cr *cmapi.CertificateRequest) (manage
 		policies = policyList.Items
 		err      error
 	)
-	for _, predicate := range m.predicates {
-		policies, err = predicate(ctx, cr, policies)
+
+	// Run matching predicates (issuer ref, namespace, RBAC).
+	for _, pred := range m.predicates {
+		policies, err = pred(ctx, cr, policies)
 		if err != nil {
 			return manager.ReviewResponse{}, fmt.Errorf("failed to perform predicate on policies: %w", err)
 		}
+	}
+
+	// Check for matching policies that haven't been reconciled yet (no Ready
+	// condition). Used below to defer terminal deny decisions during startup.
+	hasUnreconciled := hasUnreconciledPolicies(policies)
+
+	// Filter to only Ready policies for evaluation.
+	policies, err = m.readyPredicate(ctx, cr, policies)
+	if err != nil {
+		return manager.ReviewResponse{}, fmt.Errorf("failed to filter ready policies: %w", err)
 	}
 
 	// If no policies are appropriate, return ResultUnprocessed.
@@ -166,10 +179,38 @@ func (m *mngr) Review(ctx context.Context, cr *cmapi.CertificateRequest) (manage
 		messages = append(messages, fmt.Sprintf("[%s: %s]", policyMessage.name, policyMessage.message))
 	}
 
+	// Defer deny if matching policies haven't been reconciled yet — they may
+	// approve the request once Ready.
+	if hasUnreconciled {
+		return manager.ReviewResponse{
+			Result:  manager.ResultUnprocessed,
+			Message: fmt.Sprintf("Not all policies are ready for evaluation; refusing to deny pending policy readiness: %s", strings.Join(messages, " ")),
+		}, nil
+	}
+
 	// Return with all policies that we consulted, and their errors to why the
 	// request was denied.
 	return manager.ReviewResponse{
 		Result:  manager.ResultDenied,
 		Message: fmt.Sprintf("No policy approved this request: %s", strings.Join(messages, " ")),
 	}, nil
+}
+
+// hasUnreconciledPolicies returns true if any policy lacks a Ready condition
+// entirely, indicating it hasn't been reconciled yet. This is distinct from
+// Ready=False which is an explicit state set by the controller.
+func hasUnreconciledPolicies(policies []policyapi.CertificateRequestPolicy) bool {
+	for _, policy := range policies {
+		hasReadyCondition := false
+		for _, condition := range policy.Status.Conditions {
+			if condition.Type == policyapi.ConditionTypeReady {
+				hasReadyCondition = true
+				break
+			}
+		}
+		if !hasReadyCondition {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/internal/approver/manager/review_test.go
+++ b/pkg/internal/approver/manager/review_test.go
@@ -26,6 +26,7 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	policyapi "github.com/cert-manager/approver-policy/pkg/apis/policy/v1alpha1"
 	"github.com/cert-manager/approver-policy/pkg/approver"
@@ -49,11 +50,12 @@ func Test_Review(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		evaluator   func(t *testing.T) approver.Evaluator
-		predicate   func(t *testing.T) predicate.Predicate
-		policies    []policyapi.CertificateRequestPolicy
-		expResponse manager.ReviewResponse
-		expErr      bool
+		evaluator        func(t *testing.T) approver.Evaluator
+		predicate        func(t *testing.T) predicate.Predicate
+		policies         []policyapi.CertificateRequestPolicy
+		setReadyPolicies []string // policy names to set Ready condition on after creation
+		expResponse      manager.ReviewResponse
+		expErr           bool
 	}{
 		"if no CertificateRequestPolicies exist, return ResultUnprocessed": {
 			evaluator: expNoEvaluation,
@@ -102,19 +104,17 @@ func Test_Review(t *testing.T) {
 				})
 			},
 			predicate: func(t *testing.T) predicate.Predicate {
-				return func(_ context.Context, _ *cmapi.CertificateRequest, _ []policyapi.CertificateRequestPolicy) ([]policyapi.CertificateRequestPolicy, error) {
-					return []policyapi.CertificateRequestPolicy{{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-policy-a"},
-						Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
-					}}, nil
+				return func(_ context.Context, _ *cmapi.CertificateRequest, policies []policyapi.CertificateRequestPolicy) ([]policyapi.CertificateRequestPolicy, error) {
+					return policies, nil
 				}
 			},
 			policies: []policyapi.CertificateRequestPolicy{{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-policy-a"},
 				Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
 			}},
-			expResponse: manager.ReviewResponse{Result: manager.ResultDenied, Message: "No policy approved this request: [test-policy-a: this is a denied response]"},
-			expErr:      false,
+			setReadyPolicies: []string{"test-policy-a"},
+			expResponse:      manager.ReviewResponse{Result: manager.ResultDenied, Message: "No policy approved this request: [test-policy-a: this is a denied response]"},
+			expErr:           false,
 		},
 		"if single policy returns and evaluator returns not-denied, return ResultApproved": {
 			evaluator: func(t *testing.T) approver.Evaluator {
@@ -123,19 +123,17 @@ func Test_Review(t *testing.T) {
 				})
 			},
 			predicate: func(t *testing.T) predicate.Predicate {
-				return func(_ context.Context, _ *cmapi.CertificateRequest, _ []policyapi.CertificateRequestPolicy) ([]policyapi.CertificateRequestPolicy, error) {
-					return []policyapi.CertificateRequestPolicy{{
-						ObjectMeta: metav1.ObjectMeta{Name: "test-policy-a"},
-						Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
-					}}, nil
+				return func(_ context.Context, _ *cmapi.CertificateRequest, policies []policyapi.CertificateRequestPolicy) ([]policyapi.CertificateRequestPolicy, error) {
+					return policies, nil
 				}
 			},
 			policies: []policyapi.CertificateRequestPolicy{{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-policy-a"},
 				Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
 			}},
-			expResponse: manager.ReviewResponse{Result: manager.ResultApproved, Message: `Approved by CertificateRequestPolicy: "test-policy-a"`},
-			expErr:      false,
+			setReadyPolicies: []string{"test-policy-a"},
+			expResponse:      manager.ReviewResponse{Result: manager.ResultApproved, Message: `Approved by CertificateRequestPolicy: "test-policy-a"`},
+			expErr:           false,
 		},
 		"if two policies returned and evaluator returns one not-denied, return ResultApproved": {
 			evaluator: func(t *testing.T) approver.Evaluator {
@@ -147,17 +145,8 @@ func Test_Review(t *testing.T) {
 				})
 			},
 			predicate: func(t *testing.T) predicate.Predicate {
-				return func(_ context.Context, _ *cmapi.CertificateRequest, _ []policyapi.CertificateRequestPolicy) ([]policyapi.CertificateRequestPolicy, error) {
-					return []policyapi.CertificateRequestPolicy{
-						{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-policy-a"},
-							Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-policy-b"},
-							Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
-						},
-					}, nil
+				return func(_ context.Context, _ *cmapi.CertificateRequest, policies []policyapi.CertificateRequestPolicy) ([]policyapi.CertificateRequestPolicy, error) {
+					return policies, nil
 				}
 			},
 			policies: []policyapi.CertificateRequestPolicy{
@@ -170,8 +159,9 @@ func Test_Review(t *testing.T) {
 					Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
 				},
 			},
-			expResponse: manager.ReviewResponse{Result: manager.ResultApproved, Message: `Approved by CertificateRequestPolicy: "test-policy-b"`},
-			expErr:      false,
+			setReadyPolicies: []string{"test-policy-a", "test-policy-b"},
+			expResponse:      manager.ReviewResponse{Result: manager.ResultApproved, Message: `Approved by CertificateRequestPolicy: "test-policy-b"`},
+			expErr:           false,
 		},
 		"if two policies returned and both return denied, return ResultDenied": {
 			evaluator: func(t *testing.T) approver.Evaluator {
@@ -180,17 +170,8 @@ func Test_Review(t *testing.T) {
 				})
 			},
 			predicate: func(t *testing.T) predicate.Predicate {
-				return func(_ context.Context, _ *cmapi.CertificateRequest, _ []policyapi.CertificateRequestPolicy) ([]policyapi.CertificateRequestPolicy, error) {
-					return []policyapi.CertificateRequestPolicy{
-						{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-policy-a"},
-							Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
-						},
-						{
-							ObjectMeta: metav1.ObjectMeta{Name: "test-policy-b"},
-							Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
-						},
-					}, nil
+				return func(_ context.Context, _ *cmapi.CertificateRequest, policies []policyapi.CertificateRequestPolicy) ([]policyapi.CertificateRequestPolicy, error) {
+					return policies, nil
 				}
 			},
 			policies: []policyapi.CertificateRequestPolicy{
@@ -203,8 +184,37 @@ func Test_Review(t *testing.T) {
 					Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
 				},
 			},
-			expResponse: manager.ReviewResponse{Result: manager.ResultDenied, Message: "No policy approved this request: [test-policy-a: this is a denied response] [test-policy-b: this is a denied response]"},
-			expErr:      false,
+			setReadyPolicies: []string{"test-policy-a", "test-policy-b"},
+			expResponse:      manager.ReviewResponse{Result: manager.ResultDenied, Message: "No policy approved this request: [test-policy-a: this is a denied response] [test-policy-b: this is a denied response]"},
+			expErr:           false,
+		},
+		"if evaluator denies but some policies are unreconciled, return ResultUnprocessed": {
+			evaluator: func(t *testing.T) approver.Evaluator {
+				return fake.NewFakeEvaluator().WithEvaluate(func(_ context.Context, _ *policyapi.CertificateRequestPolicy, _ *cmapi.CertificateRequest) (approver.EvaluationResponse, error) {
+					return approver.EvaluationResponse{Result: approver.ResultDenied, Message: "this is a denied response"}, nil
+				})
+			},
+			predicate: func(t *testing.T) predicate.Predicate {
+				return func(_ context.Context, _ *cmapi.CertificateRequest, policies []policyapi.CertificateRequestPolicy) ([]policyapi.CertificateRequestPolicy, error) {
+					return policies, nil
+				}
+			},
+			policies: []policyapi.CertificateRequestPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-policy-deny"},
+					Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-policy-unreconciled"},
+					Spec:       policyapi.CertificateRequestPolicySpec{Selector: policyapi.CertificateRequestPolicySelector{IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{}}},
+				},
+			},
+			setReadyPolicies: []string{"test-policy-deny"},
+			expResponse: manager.ReviewResponse{
+				Result:  manager.ResultUnprocessed,
+				Message: "Not all policies are ready for evaluation; refusing to deny pending policy readiness: [test-policy-deny: this is a denied response]",
+			},
+			expErr: false,
 		},
 	}
 
@@ -227,10 +237,31 @@ func Test_Review(t *testing.T) {
 				}
 			}
 
+			// Set the Ready condition on specified policies via status subresource.
+			for _, name := range test.setReadyPolicies {
+				var policy policyapi.CertificateRequestPolicy
+				if err := env.AdminClient.Get(ctx, client.ObjectKey{Name: name}, &policy); err != nil {
+					t.Fatalf("failed to get policy %q for status update: %s", name, err)
+				}
+				policy.Status.Conditions = []metav1.Condition{
+					{
+						Type:               policyapi.ConditionTypeReady,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Ready",
+						Message:            "CertificateRequestPolicy is ready for approval evaluation",
+						LastTransitionTime: metav1.Now(),
+					},
+				}
+				if err := env.AdminClient.Status().Update(ctx, &policy); err != nil {
+					t.Fatalf("failed to update status for policy %q: %s", name, err)
+				}
+			}
+
 			mngr := &mngr{
-				lister:     env.AdminClient,
-				predicates: []predicate.Predicate{test.predicate(t)},
-				evaluators: []approver.Evaluator{test.evaluator(t)},
+				lister:         env.AdminClient,
+				readyPredicate: predicate.Ready,
+				predicates:     []predicate.Predicate{test.predicate(t)},
+				evaluators:     []approver.Evaluator{test.evaluator(t)},
 			}
 
 			response, err := mngr.Review(ctx, &cmapi.CertificateRequest{


### PR DESCRIPTION
## Summary

Fixes #830 - Race condition where a default deny policy denies certificate requests before approving policies finish initializing during startup.

**Root cause:** During startup, the validating webhook is unavailable for several seconds. Policy status patches are retried until it comes up. When the default deny policy's Ready status patch succeeds first, it triggers CertificateRequest evaluation. At that moment, approving policies haven't been reconciled yet (no Ready condition), so they're filtered out by the Ready predicate. Only the deny policy is evaluated, producing a terminal Denied decision.

**Fix:** Before making a terminal Denied decision in `Review()`, check if any policies have never been reconciled (no Ready condition at all). If unreconciled policies exist, return `ResultUnprocessed` instead of `ResultDenied`, allowing the request to be re-evaluated once all policies finish initializing. This distinguishes between:
- Policies with no Ready condition (never reconciled, e.g. webhook unavailable) -- defer deny decisions
- Policies with Ready=False (deliberately not ready, e.g. misconfigured) -- allow deny decisions

**Changes:**
- `pkg/internal/approver/manager/review.go`: Added `hasUnreconciledPolicies()` check before terminal deny decisions
- `pkg/internal/approver/manager/review_test.go`: Updated existing deny tests to set Ready conditions on policies, added new test case for the race condition scenario