### PR TITLE
Switch to using default reference over chart version

### DIFF
--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: {{ include "cert-manager-approver-policy.name" . }}
       containers:
       - name: {{ include "cert-manager-approver-policy.name" . }}
-        image: "{{ template "image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" $.Chart.AppVersion)) }}"
+        image: "{{ template "image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace .Values.image._defaultReference) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - name: webhook

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -400,6 +400,9 @@
     "helm-values.image": {
       "additionalProperties": false,
       "properties": {
+        "_defaultReference": {
+          "$ref": "#/$defs/helm-values.image._defaultReference"
+        },
         "digest": {
           "$ref": "#/$defs/helm-values.image.digest"
         },
@@ -420,6 +423,11 @@
         }
       },
       "type": "object"
+    },
+    "helm-values.image._defaultReference": {
+      "default": ":v0.0.0",
+      "description": "WARNING: For internal use only; overwritten before releasing the chart.",
+      "type": "string"
     },
     "helm-values.image.digest": {
       "description": "Target image digest. Override any tag, if set.\nFor example:\ndigest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20",

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -81,6 +81,10 @@ image:
   # Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 
+  # WARNING: For internal use only; overwritten before releasing the chart.
+  # +docs:hidden
+  _defaultReference: :v0.0.0
+
 # Optional secrets used for pulling the approver-policy container image.
 imagePullSecrets: []
 

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -38,5 +38,7 @@ helm_labels_template_name := cert-manager-approver-policy.labels
 golangci_lint_config := .golangci.yaml
 
 define helm_values_mutation_function
-echo "OK: nothing to mutate in Helm values"
+$(YQ) \
+	'( .image._defaultReference = ":$(oci_manager_image_tag)" )' \
+	$1 --inplace
 endef


### PR DESCRIPTION
## Long Description

This change mirrors similar changes to those seen in e.g. how csi-driver handles versions for the [node-driver-registrar image](https://github.com/cert-manager/csi-driver/blob/80e19aedac888ed4284b1bd314aa777f134bc916/deploy/charts/csi-driver/values.yaml#L154-L156).

The plugin model for approver-policy is unusual - it effectively encourages that the plugin include + build the rest of approver policy and be distributed as a single image. This is the case for Palo Alto's [Enterprise Approver Policy](https://docs.cyberark.com/mis-saas/vaas/k8s-components/c-ape-overview/). In turn, the plugin uses this chart as a dependency.

If we have `approver-policy:v1` and `plugin:v2` we need to be able to set the value of `.Values.cert-manager-approver-policy.image.tag` in the plugin chart to `v2` to match the plugin image's tag. But we don't want to directly set `image.tag` because that makes for a poor UX when users want to set `image.digest` (forcing them to remove `image.tag` manually in some cases but not all).

This change will be a no-op for approver-policy, while allowing the plugin to overwrite _defaultReference without causing any UX problems.

## Short Description

This change doesn't change anything for approver-policy users, but it makes life for plugin developers a lot simpler while enabling a good UX for consumers of plugin charts which are based on this one.