### PR TITLE
fix: use correct CEL operator <= instead of =< in examples

### DIFF
--- a/design/20230726-cel-policy.md
+++ b/design/20230726-cel-policy.md
@@ -225,7 +225,7 @@ spec:
         - "*.sub.domain.com"
       validations:
         - message: dnsName can be maximum 64 characters.
-          rule: self.size() =< 64
+          rule: self.size() <= 64
 ```
 
 For this example, I would expect the attribute to be checked against the `values` first. If the `DNSName` CSR attribute

--- a/docs/examples/all-options.yaml
+++ b/docs/examples/all-options.yaml
@@ -17,7 +17,7 @@ spec:
         - "example.com"
         - "*.example.com"
       validations:
-        - rule: self.size() =< 24
+        - rule: self.size() <= 24
           message: DNSName must be no more than 24 characters
     ipAddresses:
       required: false
@@ -37,7 +37,7 @@ spec:
       values:
         - "*@example.com"
       validations:
-        - rule: self.size() =< 24
+        - rule: self.size() <= 24
           message: EmailAddress must be no more than 24 characters
     isCA: false
     usages:


### PR DESCRIPTION
Fix invalid CEL comparison operator `=<` to the correct `<=` in example YAML and design doc. The `=<` operator is not valid CEL syntax and would cause a compilation error if users copy these examples.