### PR TITLE
test: add unit tests for registry package

### DIFF
--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -25,10 +25,6 @@ import (
 	"github.com/cert-manager/approver-policy/pkg/approver/fake"
 )
 
-func newFakeApprover(name string) approver.Interface {
-	return fake.NewFakeApprover().WithReconciler(fake.NewFakeReconciler().WithName(name))
-}
-
 func TestRegistry_Store(t *testing.T) {
 	tests := map[string]struct {
 		preStored    []approver.Interface
@@ -137,4 +133,8 @@ func TestRegistry_Store_IncrementalAdd(t *testing.T) {
 	r.Store(newFakeApprover("second"))
 	assert.Equal(t, 2, len(r.Approvers()))
 	assert.Equal(t, 2, len(r.Reconcilers()))
+}
+
+func newFakeApprover(name string) approver.Interface {
+	return fake.NewFakeApprover().WithReconciler(fake.NewFakeReconciler().WithName(name))
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	policyapi "github.com/cert-manager/approver-policy/pkg/apis/policy/v1alpha1"
+	"github.com/cert-manager/approver-policy/pkg/approver"
+)
+
+// fakeApprover is a minimal implementation of approver.Interface for testing.
+type fakeApprover struct {
+	name string
+}
+
+func (f *fakeApprover) Name() string { return f.name }
+func (f *fakeApprover) RegisterFlags(_ *pflag.FlagSet) {}
+func (f *fakeApprover) Prepare(_ context.Context, _ logr.Logger, _ manager.Manager) error {
+	return nil
+}
+func (f *fakeApprover) Evaluate(_ context.Context, _ *policyapi.CertificateRequestPolicy, _ *cmapi.CertificateRequest) (approver.EvaluationResponse, error) {
+	return approver.EvaluationResponse{}, nil
+}
+func (f *fakeApprover) Validate(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.WebhookValidationResponse, error) {
+	return approver.WebhookValidationResponse{Allowed: true, Errors: field.ErrorList{}}, nil
+}
+func (f *fakeApprover) Ready(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
+	return approver.ReconcilerReadyResponse{Ready: true}, nil
+}
+func (f *fakeApprover) EnqueueChan() <-chan string { return nil }
+
+func TestRegistry_Store(t *testing.T) {
+	tests := map[string]struct {
+		approvers    []approver.Interface
+		expectLen    int
+		expectPanic  bool
+		panicMessage string
+	}{
+		"storing a single approver should succeed": {
+			approvers: []approver.Interface{&fakeApprover{name: "test-1"}},
+			expectLen: 1,
+		},
+		"storing multiple approvers should succeed": {
+			approvers: []approver.Interface{
+				&fakeApprover{name: "test-1"},
+				&fakeApprover{name: "test-2"},
+				&fakeApprover{name: "test-3"},
+			},
+			expectLen: 3,
+		},
+		"storing approvers with duplicate names should panic": {
+			approvers:    []approver.Interface{&fakeApprover{name: "duplicate"}},
+			expectPanic:  true,
+			panicMessage: "approver already registered with same name: duplicate",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := &Registry{}
+
+			if test.expectPanic {
+				// Pre-store an approver with the same name to trigger the panic.
+				r.Store(&fakeApprover{name: "duplicate"})
+				assert.PanicsWithValue(t, test.panicMessage, func() {
+					r.Store(test.approvers...)
+				})
+				return
+			}
+
+			r.Store(test.approvers...)
+			assert.Equal(t, test.expectLen, len(r.Approvers()))
+		})
+	}
+}
+
+func TestRegistry_Store_Chaining(t *testing.T) {
+	r := &Registry{}
+	result := r.Store(&fakeApprover{name: "a"})
+	assert.Equal(t, r, result, "Store should return the registry for chaining")
+}
+
+func TestRegistry_Approvers(t *testing.T) {
+	r := &Registry{}
+	a1 := &fakeApprover{name: "approver-1"}
+	a2 := &fakeApprover{name: "approver-2"}
+	r.Store(a1, a2)
+
+	result := r.Approvers()
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, "approver-1", result[0].Name())
+	assert.Equal(t, "approver-2", result[1].Name())
+}
+
+func TestRegistry_Evaluators(t *testing.T) {
+	r := &Registry{}
+	r.Store(&fakeApprover{name: "eval-1"}, &fakeApprover{name: "eval-2"})
+
+	evaluators := r.Evaluators()
+	assert.Equal(t, 2, len(evaluators))
+}
+
+func TestRegistry_Webhooks(t *testing.T) {
+	r := &Registry{}
+	r.Store(&fakeApprover{name: "wh-1"}, &fakeApprover{name: "wh-2"})
+
+	webhooks := r.Webhooks()
+	assert.Equal(t, 2, len(webhooks))
+}
+
+func TestRegistry_Reconcilers(t *testing.T) {
+	r := &Registry{}
+	r.Store(&fakeApprover{name: "rec-1"}, &fakeApprover{name: "rec-2"})
+
+	reconcilers := r.Reconcilers()
+	assert.Equal(t, 2, len(reconcilers))
+}
+
+func TestRegistry_EmptyRegistry(t *testing.T) {
+	r := &Registry{}
+
+	assert.Empty(t, r.Approvers())
+	assert.Empty(t, r.Evaluators())
+	assert.Empty(t, r.Webhooks())
+	assert.Empty(t, r.Reconcilers())
+}
+
+func TestRegistry_Store_IncrementalAdd(t *testing.T) {
+	r := &Registry{}
+	r.Store(&fakeApprover{name: "first"})
+	assert.Equal(t, 1, len(r.Approvers()))
+
+	r.Store(&fakeApprover{name: "second"})
+	assert.Equal(t, 2, len(r.Approvers()))
+
+	result := r.Reconcilers()
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, ctrl.Result{}, approver.ReconcilerReadyResponse{Ready: true}.Result)
+}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -17,64 +17,41 @@ limitations under the License.
 package registry
 
 import (
-	"context"
 	"testing"
 
-	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
 
-	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	policyapi "github.com/cert-manager/approver-policy/pkg/apis/policy/v1alpha1"
 	"github.com/cert-manager/approver-policy/pkg/approver"
+	"github.com/cert-manager/approver-policy/pkg/approver/fake"
 )
 
-// fakeApprover is a minimal implementation of approver.Interface for testing.
-type fakeApprover struct {
-	name string
+func newFakeApprover(name string) approver.Interface {
+	return fake.NewFakeApprover().WithReconciler(fake.NewFakeReconciler().WithName(name))
 }
-
-func (f *fakeApprover) Name() string { return f.name }
-func (f *fakeApprover) RegisterFlags(_ *pflag.FlagSet) {}
-func (f *fakeApprover) Prepare(_ context.Context, _ logr.Logger, _ manager.Manager) error {
-	return nil
-}
-func (f *fakeApprover) Evaluate(_ context.Context, _ *policyapi.CertificateRequestPolicy, _ *cmapi.CertificateRequest) (approver.EvaluationResponse, error) {
-	return approver.EvaluationResponse{}, nil
-}
-func (f *fakeApprover) Validate(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.WebhookValidationResponse, error) {
-	return approver.WebhookValidationResponse{Allowed: true, Errors: field.ErrorList{}}, nil
-}
-func (f *fakeApprover) Ready(_ context.Context, _ *policyapi.CertificateRequestPolicy) (approver.ReconcilerReadyResponse, error) {
-	return approver.ReconcilerReadyResponse{Ready: true}, nil
-}
-func (f *fakeApprover) EnqueueChan() <-chan string { return nil }
 
 func TestRegistry_Store(t *testing.T) {
 	tests := map[string]struct {
+		preStored    []approver.Interface
 		approvers    []approver.Interface
 		expectLen    int
 		expectPanic  bool
 		panicMessage string
 	}{
 		"storing a single approver should succeed": {
-			approvers: []approver.Interface{&fakeApprover{name: "test-1"}},
+			approvers: []approver.Interface{newFakeApprover("test-1")},
 			expectLen: 1,
 		},
 		"storing multiple approvers should succeed": {
 			approvers: []approver.Interface{
-				&fakeApprover{name: "test-1"},
-				&fakeApprover{name: "test-2"},
-				&fakeApprover{name: "test-3"},
+				newFakeApprover("test-1"),
+				newFakeApprover("test-2"),
+				newFakeApprover("test-3"),
 			},
 			expectLen: 3,
 		},
 		"storing approvers with duplicate names should panic": {
-			approvers:    []approver.Interface{&fakeApprover{name: "duplicate"}},
+			preStored:    []approver.Interface{newFakeApprover("duplicate")},
+			approvers:    []approver.Interface{newFakeApprover("duplicate")},
 			expectPanic:  true,
 			panicMessage: "approver already registered with same name: duplicate",
 		},
@@ -84,9 +61,11 @@ func TestRegistry_Store(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			r := &Registry{}
 
+			for _, a := range test.preStored {
+				r.Store(a)
+			}
+
 			if test.expectPanic {
-				// Pre-store an approver with the same name to trigger the panic.
-				r.Store(&fakeApprover{name: "duplicate"})
 				assert.PanicsWithValue(t, test.panicMessage, func() {
 					r.Store(test.approvers...)
 				})
@@ -101,14 +80,14 @@ func TestRegistry_Store(t *testing.T) {
 
 func TestRegistry_Store_Chaining(t *testing.T) {
 	r := &Registry{}
-	result := r.Store(&fakeApprover{name: "a"})
+	result := r.Store(newFakeApprover("a"))
 	assert.Equal(t, r, result, "Store should return the registry for chaining")
 }
 
 func TestRegistry_Approvers(t *testing.T) {
 	r := &Registry{}
-	a1 := &fakeApprover{name: "approver-1"}
-	a2 := &fakeApprover{name: "approver-2"}
+	a1 := newFakeApprover("approver-1")
+	a2 := newFakeApprover("approver-2")
 	r.Store(a1, a2)
 
 	result := r.Approvers()
@@ -119,7 +98,7 @@ func TestRegistry_Approvers(t *testing.T) {
 
 func TestRegistry_Evaluators(t *testing.T) {
 	r := &Registry{}
-	r.Store(&fakeApprover{name: "eval-1"}, &fakeApprover{name: "eval-2"})
+	r.Store(newFakeApprover("eval-1"), newFakeApprover("eval-2"))
 
 	evaluators := r.Evaluators()
 	assert.Equal(t, 2, len(evaluators))
@@ -127,7 +106,7 @@ func TestRegistry_Evaluators(t *testing.T) {
 
 func TestRegistry_Webhooks(t *testing.T) {
 	r := &Registry{}
-	r.Store(&fakeApprover{name: "wh-1"}, &fakeApprover{name: "wh-2"})
+	r.Store(newFakeApprover("wh-1"), newFakeApprover("wh-2"))
 
 	webhooks := r.Webhooks()
 	assert.Equal(t, 2, len(webhooks))
@@ -135,7 +114,7 @@ func TestRegistry_Webhooks(t *testing.T) {
 
 func TestRegistry_Reconcilers(t *testing.T) {
 	r := &Registry{}
-	r.Store(&fakeApprover{name: "rec-1"}, &fakeApprover{name: "rec-2"})
+	r.Store(newFakeApprover("rec-1"), newFakeApprover("rec-2"))
 
 	reconcilers := r.Reconcilers()
 	assert.Equal(t, 2, len(reconcilers))
@@ -152,13 +131,10 @@ func TestRegistry_EmptyRegistry(t *testing.T) {
 
 func TestRegistry_Store_IncrementalAdd(t *testing.T) {
 	r := &Registry{}
-	r.Store(&fakeApprover{name: "first"})
+	r.Store(newFakeApprover("first"))
 	assert.Equal(t, 1, len(r.Approvers()))
 
-	r.Store(&fakeApprover{name: "second"})
+	r.Store(newFakeApprover("second"))
 	assert.Equal(t, 2, len(r.Approvers()))
-
-	result := r.Reconcilers()
-	assert.Equal(t, 2, len(result))
-	assert.Equal(t, ctrl.Result{}, approver.ReconcilerReadyResponse{Ready: true}.Result)
+	assert.Equal(t, 2, len(r.Reconcilers()))
 }


### PR DESCRIPTION
Add unit tests for `pkg/registry` covering all public methods of the `Registry` type.