### PR TITLE
fix: use %w verb for proper error wrapping

### DIFF
--- a/pkg/internal/cmd/options/options.go
+++ b/pkg/internal/cmd/options/options.go
@@ -167,7 +167,7 @@ func (o *Options) Complete() error {
 	var err error
 	o.RestConfig, err = o.kubeConfigFlags.ToRESTConfig()
 	if err != nil {
-		return fmt.Errorf("failed to build kubernetes rest config: %s", err)
+		return fmt.Errorf("failed to build kubernetes rest config: %w", err)
 	}
 
 	return nil

--- a/pkg/internal/webhook/webhook.go
+++ b/pkg/internal/webhook/webhook.go
@@ -68,11 +68,11 @@ func Register(ctx context.Context, opts Options) error {
 		WithValidator(validator).
 		Complete()
 	if err != nil {
-		return fmt.Errorf("error registering webhook: %v", err)
+		return fmt.Errorf("error registering webhook: %w", err)
 	}
 
 	if err := opts.Manager.AddReadyzCheck("validator", opts.Manager.GetWebhookServer().StartedChecker()); err != nil {
-		return fmt.Errorf("error adding readyz check: %v", err)
+		return fmt.Errorf("error adding readyz check: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Use `%w` instead of `%v`/`%s` in `fmt.Errorf` calls to enable `errors.Is` and `errors.As` for error inspection.