### PR TITLE
Disable client side rate limiting

### DIFF
--- a/pkg/internal/cmd/options/options.go
+++ b/pkg/internal/cmd/options/options.go
@@ -174,6 +174,9 @@ func (o *Options) Complete() error {
 		return fmt.Errorf("failed to build kubernetes rest config: %w", err)
 	}
 
+	// Disable client-side ratelimer, we can rely on API priority and fairness
+	o.RestConfig.QPS = -1
+
 	return nil
 }
 


### PR DESCRIPTION
**UPDATE:** Disables Client side rate limiting as discussed on the weekly meeting


**Old description:**
adds ability to set kube api qps/burst as well as max concurrent reconciles. passed in as arguments to the process. uses changes current defaults defaults (1 max reconcile, and 5 qps & 10 burst) to be disabled (controller-runtime also disables it)

in my current environment (without this change), we're currently running into bottlenecks with the approver policy and sometimes takes 1.5 mins to reconcile due to the spiky nature of how deploys happen. This allows us to be more agressive with the reconciles & the kube api client rate limiting. 

ex:
```
      containers:
      - args:
        - --kube-api-qps=5 # set to previous default
        - --kube-api-burst=10 # set to previous default
        - --certificaterequest-max-concurrent-reconciles=10
        - --certificaterequestpolicy-max-concurrent-reconciles=1
        - ...
```


```
time=2026-03-31T22:53:58.162Z level=INFO msg="Starting workers" controller=certificaterequestpolicy controllerGroup=policy.cert-manager.io controllerKind=CertificateRequestPolicy logger=controller-manager "worker count"=1
time=2026-03-31T22:53:58.462Z level=INFO msg="Starting workers" controller=certificaterequest controllerGroup=cert-manager.io controllerKind=CertificateRequest logger=controller-manager "worker count"=10
```