### PR TITLE
Cleanup code by using cache-backed controller-runtime Client

### DIFF
--- a/pkg/internal/approver/manager/predicate/predicate.go
+++ b/pkg/internal/approver/manager/predicate/predicate.go
@@ -98,7 +98,7 @@ func SelectorIssuerRef(_ context.Context, cr *cmapi.CertificateRequest, policies
 // the request. SelectorNamespace will match with `namespace.matchNames` on
 // namespaces using wilcards "*". Empty selector is equivalent to "*" and will
 // match on any Namespace.
-func SelectorNamespace(lister client.Reader) Predicate {
+func SelectorNamespace(reader client.Reader) Predicate {
 	return func(ctx context.Context, request *cmapi.CertificateRequest, policies []policyapi.CertificateRequestPolicy) ([]policyapi.CertificateRequestPolicy, error) {
 		var matchingPolicies []policyapi.CertificateRequestPolicy
 
@@ -143,7 +143,7 @@ func SelectorNamespace(lister client.Reader) Predicate {
 
 				if namespaceLabels == nil {
 					var namespace corev1.Namespace
-					if err := lister.Get(ctx, client.ObjectKey{Name: request.Namespace}, &namespace); err != nil {
+					if err := reader.Get(ctx, client.ObjectKey{Name: request.Namespace}, &namespace); err != nil {
 						return nil, fmt.Errorf("failed to get request's namespace to determine namespace selector: %w", err)
 					}
 					namespaceLabels = &namespace.Labels

--- a/pkg/internal/approver/manager/review.go
+++ b/pkg/internal/approver/manager/review.go
@@ -37,7 +37,7 @@ var _ manager.Interface = &mngr{}
 // filtering CertificiateRequestPolicies based on predicates, and evaluating
 // CertificateRequests using the registered evaluators.
 type mngr struct {
-	lister         client.Reader
+	reader         client.Reader
 	readyPredicate predicate.Predicate
 	predicates     []predicate.Predicate
 	evaluators     []approver.Evaluator
@@ -65,13 +65,13 @@ type policyMessage struct {
 // IssuerRef
 //   - CertificateRequestPolicy is bound to the user that appears in the
 //     CertificateRequest
-func New(lister client.Reader, client client.Client, evaluators []approver.Evaluator) manager.Interface {
+func New(client client.Client, evaluators []approver.Evaluator) manager.Interface {
 	return &mngr{
-		lister:         lister,
+		reader:         client,
 		readyPredicate: predicate.Ready,
 		predicates: []predicate.Predicate{
 			predicate.SelectorIssuerRef,
-			predicate.SelectorNamespace(lister),
+			predicate.SelectorNamespace(client),
 			predicate.RBACBound(client),
 		},
 		evaluators: evaluators,
@@ -83,7 +83,7 @@ func New(lister client.Reader, client client.Client, evaluators []approver.Evalu
 // have passed all of the predicates.
 func (m *mngr) Review(ctx context.Context, cr *cmapi.CertificateRequest) (manager.ReviewResponse, error) {
 	policyList := new(policyapi.CertificateRequestPolicyList)
-	if err := m.lister.List(ctx, policyList); err != nil {
+	if err := m.reader.List(ctx, policyList); err != nil {
 		return manager.ReviewResponse{}, err
 	}
 

--- a/pkg/internal/approver/manager/review_test.go
+++ b/pkg/internal/approver/manager/review_test.go
@@ -258,7 +258,7 @@ func Test_Review(t *testing.T) {
 			}
 
 			mngr := &mngr{
-				lister:         env.AdminClient,
+				reader:         env.AdminClient,
 				readyPredicate: predicate.Ready,
 				predicates:     []predicate.Predicate{test.predicate(t)},
 				evaluators:     []approver.Evaluator{test.evaluator(t)},

--- a/pkg/internal/controllers/certificaterequestpolicies.go
+++ b/pkg/internal/controllers/certificaterequestpolicies.go
@@ -61,10 +61,6 @@ type certificaterequestpolicies struct {
 	// server.
 	client client.Client
 
-	// lister makes requests to the informer cache for getting and listing
-	// objects.
-	lister client.Reader
-
 	// reconcilers is the set of approver Reconcilers that are responsible for
 	// building the Ready status conditions of CertificateRequestPolicies.
 	// CertificateRequestPolicies that are not in a Ready state will not be used
@@ -132,7 +128,6 @@ func addCertificateRequestPolicyController(_ context.Context, opts Options) erro
 			clock:       clock.RealClock{},
 			recorder:    opts.Manager.GetEventRecorder("policy.cert-manager.io"),
 			client:      opts.Manager.GetClient(),
-			lister:      opts.Manager.GetCache(),
 			reconcilers: opts.Reconcilers,
 		})
 }
@@ -170,7 +165,7 @@ func (c *certificaterequestpolicies) reconcileStatusPatch(ctx context.Context, r
 	log.V(2).Info("syncing")
 
 	policy := new(policyapi.CertificateRequestPolicy)
-	if err := c.lister.Get(ctx, req.NamespacedName, policy); err != nil {
+	if err := c.client.Get(ctx, req.NamespacedName, policy); err != nil {
 		return reconcile.Result{}, nil, client.IgnoreNotFound(err)
 	}
 

--- a/pkg/internal/controllers/certificaterequestpolicies_test.go
+++ b/pkg/internal/controllers/certificaterequestpolicies_test.go
@@ -419,7 +419,6 @@ func Test_certificaterequestpolicies_Reconcile(t *testing.T) {
 				log:         ktesting.NewLogger(t, ktesting.DefaultConfig),
 				clock:       fixedclock,
 				client:      fakeclient,
-				lister:      fakeclient,
 				recorder:    fakerecorder,
 				reconcilers: test.reconcilers,
 			}

--- a/pkg/internal/controllers/certificaterequests.go
+++ b/pkg/internal/controllers/certificaterequests.go
@@ -65,10 +65,6 @@ type certificaterequests struct {
 	// server.
 	client client.Client
 
-	// lister makes requests to the informer cache for getting and listing
-	// objects.
-	lister client.Reader
-
 	// manager is a Manager that is responsible for reviewing whether a
 	// CertificateRequest should be approved or denied. This manager is expected
 	// to manage all approvers which have been registered and active for this
@@ -84,8 +80,7 @@ func addCertificateRequestController(ctx context.Context, opts Options) error {
 		clock:    clock.RealClock{},
 		recorder: opts.Manager.GetEventRecorder("policy.cert-manager.io"),
 		client:   opts.Manager.GetClient(),
-		lister:   opts.Manager.GetCache(),
-		manager:  internalmanager.New(opts.Manager.GetCache(), opts.Manager.GetClient(), opts.Evaluators),
+		manager:  internalmanager.New(opts.Manager.GetClient(), opts.Evaluators),
 	}
 
 	enqueueRequestFromMapFunc := func(_ context.Context, _ client.Object) []reconcile.Request {
@@ -94,7 +89,7 @@ func addCertificateRequestController(ctx context.Context, opts Options) error {
 		// Exiting error is the safest option, as it will force a resync on all
 		// CertificateRequests on start.
 		var crList cmapi.CertificateRequestList
-		if err := c.lister.List(ctx, &crList); err != nil {
+		if err := c.client.List(ctx, &crList); err != nil {
 			c.log.Error(err, "failed to list all CertificateRequests, exiting error")
 			os.Exit(-1)
 		}
@@ -179,7 +174,7 @@ func (c *certificaterequests) reconcileStatusPatch(ctx context.Context, req ctrl
 	log.V(2).Info("syncing certificaterequest")
 
 	cr := new(cmapi.CertificateRequest)
-	if err := c.lister.Get(ctx, req.NamespacedName, cr); err != nil {
+	if err := c.client.Get(ctx, req.NamespacedName, cr); err != nil {
 		return ctrl.Result{}, nil, client.IgnoreNotFound(err)
 	}
 

--- a/pkg/internal/controllers/certificaterequests_test.go
+++ b/pkg/internal/controllers/certificaterequests_test.go
@@ -187,7 +187,6 @@ func Test_certificaterequests_Reconcile(t *testing.T) {
 
 			c := &certificaterequests{
 				client:   fakeclient,
-				lister:   fakeclient,
 				recorder: fakerecorder,
 				manager:  test.manager,
 				log:      ktesting.NewLogger(t, ktesting.DefaultConfig),

--- a/pkg/internal/webhook/validator.go
+++ b/pkg/internal/webhook/validator.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	policyapi "github.com/cert-manager/approver-policy/pkg/apis/policy/v1alpha1"
@@ -39,8 +38,6 @@ type validator struct {
 
 	registeredPlugins []string
 	webhooks          []approver.Webhook
-
-	lister client.Reader
 }
 
 var _ admission.Validator[*policyapi.CertificateRequestPolicy] = &validator{}

--- a/pkg/internal/webhook/validator_test.go
+++ b/pkg/internal/webhook/validator_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	policyapi "github.com/cert-manager/approver-policy/pkg/apis/policy/v1alpha1"
@@ -203,11 +202,7 @@ func Test_validate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			fakeclient := fakeclient.NewClientBuilder().
-				WithScheme(policyapi.GlobalScheme).
-				Build()
-
-			v := &validator{lister: fakeclient, log: ktesting.NewLogger(t, ktesting.DefaultConfig), webhooks: test.webhooks, registeredPlugins: test.registeredPlugins}
+			v := &validator{log: ktesting.NewLogger(t, ktesting.DefaultConfig), webhooks: test.webhooks, registeredPlugins: test.registeredPlugins}
 			gotWarnings, gotErr := v.validate(t.Context(), test.crp)
 			if test.expectedError == nil && gotErr != nil {
 				t.Errorf("unexpected error: %v", gotErr)

--- a/pkg/internal/webhook/webhook.go
+++ b/pkg/internal/webhook/webhook.go
@@ -46,7 +46,7 @@ type Options struct {
 
 // Register the approver-policy Webhook endpoints against the
 // controller-manager Manager.
-func Register(ctx context.Context, opts Options) error {
+func Register(_ context.Context, opts Options) error {
 	log := opts.Log.WithName("webhook")
 
 	var registerdPlugins []string
@@ -59,7 +59,6 @@ func Register(ctx context.Context, opts Options) error {
 	log.Info("registering webhook endpoints")
 	validator := &validator{
 		log:               log.WithName("validation"),
-		lister:            opts.Manager.GetCache(),
 		webhooks:          opts.Webhooks,
 		registeredPlugins: registerdPlugins,
 	}


### PR DESCRIPTION
I find it confusing to access the controller-runtime cache directly when not required to. The default controller-runtime client is backed by the cache, and there is all sorts of smartness built into it. I don't think it fixes https://github.com/cert-manager/approver-policy/issues/819, but it certainly makes the code cleaner and more compact.