### PR TITLE
fix: rename image helper to avoid umbrella chart conflicts

### DIFF
--- a/deploy/charts/approver-policy/templates/_helpers.tpl
+++ b/deploy/charts/approver-policy/templates/_helpers.tpl
@@ -34,7 +34,7 @@ IMPORTANT: This function is standardized across all charts in the cert-manager G
 Any changes to this function should also be made in cert-manager, trust-manager, approver-policy, ...
 See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linked PRs.
 */}}
-{{- define "image" -}}
+{{- define "approver-policy.image" -}}
 {{- /*
 Calling convention:
 

--- a/deploy/charts/approver-policy/templates/_helpers.tpl
+++ b/deploy/charts/approver-policy/templates/_helpers.tpl
@@ -46,7 +46,7 @@ usage through tuple/variable indirection.
 */ -}}
 
 {{- if ne (len .) 4 -}}
-  {{- fail (printf "ERROR: template \"image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
+  {{- fail (printf "ERROR: template \"approver-policy.image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
 {{- end -}}
 
 {{- $image := index . 0 -}}

--- a/deploy/charts/approver-policy/templates/deployment.yaml
+++ b/deploy/charts/approver-policy/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: {{ include "cert-manager-approver-policy.name" . }}
       containers:
       - name: {{ include "cert-manager-approver-policy.name" . }}
-        image: "{{ template "image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace .Values.image._defaultReference) }}"
+        image: "{{ template "approver-policy.image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace .Values.image._defaultReference) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - name: webhook


### PR DESCRIPTION
Part of a group of PRs aiming to fix the issues reported here:

https://github.com/cert-manager/google-cas-issuer/issues/487

https://github.com/cert-manager/trust-manager/issues/908