### PR TITLE
BUGFIX: Fetch cached namespace metadata only

### DIFF
--- a/pkg/internal/approver/manager/predicate/predicate.go
+++ b/pkg/internal/approver/manager/predicate/predicate.go
@@ -22,7 +22,6 @@ import (
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	authzv1 "k8s.io/api/authorization/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -142,8 +141,8 @@ func SelectorNamespace(reader client.Reader) Predicate {
 			if nsSel.MatchLabels != nil {
 
 				if namespaceLabels == nil {
-					var namespace corev1.Namespace
-					if err := reader.Get(ctx, client.ObjectKey{Name: request.Namespace}, &namespace); err != nil {
+					namespace := &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"}}
+					if err := reader.Get(ctx, client.ObjectKey{Name: request.Namespace}, namespace); err != nil {
 						return nil, fmt.Errorf("failed to get request's namespace to determine namespace selector: %w", err)
 					}
 					namespaceLabels = &namespace.Labels

--- a/pkg/internal/controllers/test/util.go
+++ b/pkg/internal/controllers/test/util.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2/ktesting"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -217,6 +218,9 @@ func startControllers(registry *registry.Registry) (context.Context, func(), cor
 			// need to skip unique controller name validation
 			// since all tests need a dedicated controller
 			SkipNameValidation: new(true),
+		},
+		Cache: cache.Options{
+			ReaderFailOnMissingInformer: true,
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/cert-manager/approver-policy/pull/860. When enabling the `ReaderFailOnMissingInformer` cache setting in controller-runtime, and have configured watches to only watch metadata, we need to use `PartialObjectMetadata` when getting/listing resources.

We already have integration tests covering this, but in https://github.com/cert-manager/approver-policy/pull/860, we forgot to enable `ReaderFailOnMissingInformer` for the test manager. I have added the missing test setup to the PR, and if I run the tests without the fix, I get the following result:

````
  [FAILED] Timed out after 10.004s.
  expected approval                                                                                                                                                                                                               
  Expected                                                                                                                                                                                                                        
      <bool>: false                                                                                                                                                                                                               
  to be true                                                                                                                                                                                                                      
  In [It] at: /home/erikbo/projects/github/approver-policy/pkg/internal/controllers/test/util.go:57 @ 04/30/26 23:16:32.914
------------------------------
•••••••••

Summarizing 2 Failures:
  [FAIL] Selector [It] it should select on all CertificateRequests where namespace={matchLabels=[foo=bar]}, RBAC bound, and plugin return Ready
  /home/erikbo/projects/github/approver-policy/pkg/internal/controllers/test/util.go:57
  [FAIL] Selector [It] if namespace selector doesn't match, don't approve or deny. If selector updated with match, should approve CertificateRequest
  /home/erikbo/projects/github/approver-policy/pkg/internal/controllers/test/util.go:57

Ran 50 of 50 Specs in 229.201 seconds
FAIL! -- 48 Passed | 2 Failed | 0 Pending | 0 Skipped
````

And I can also observe the error message reported in https://github.com/cert-manager/approver-policy/issues/891 for the failing tests.

Fixes https://github.com/cert-manager/approver-policy/issues/891