### PR TITLE
BUGFIX: Make ValidatingWebhookConfiguration precise

### DIFF
--- a/deploy/charts/approver-policy/templates/webhook.yaml
+++ b/deploy/charts/approver-policy/templates/webhook.yaml
@@ -40,7 +40,7 @@ webhooks:
           - CREATE
           - UPDATE
         resources:
-          - "*/*"
+          - certificaterequestpolicies
     admissionReviewVersions: ["v1", "v1beta1"]
     timeoutSeconds: {{ .Values.app.webhook.timeoutSeconds }}
     failurePolicy: Fail


### PR DESCRIPTION
Our ValidatingWebhookConfiguration has an incorrect (too generic) configuration, which may result in startup issues. We should probably also select the API version more precisely, but for now, let's fix the main issue of resource status update requests being intercepted by the webhook.

Fixes https://github.com/cert-manager/approver-policy/issues/907