### PR TITLE
VC-53793: Add CEL cost limit

### DIFF
--- a/design/20230726-cel-policy.md
+++ b/design/20230726-cel-policy.md
@@ -457,3 +457,29 @@ Let me start with a quote from the
 The last sentence describes the requirement that could need custom CEL function(s) to allow the user to specify allowed
 CSR attributes. We cannot expect the user to include validations for **all** CSR attributes in the expression(s). So I
 think we at least need a function to list allowed CSR attribute usage.
+
+## Addendum: CEL runtime cost limit (June 2025)
+
+A security review identified that a deeply nested comprehension (e.g. 8-deep
+`[0..9].all(...)` — 10^8 iterations) can hang the single reconcile worker
+indefinitely, blocking all certificate approvals cluster-wide. Even though
+`CertificateRequestPolicy` is cluster-scoped and restricted to admins,
+accidental complexity in a rule can trigger this.
+
+As a mitigation, **`cel.CostLimit(1000000)`** and
+**`cel.InterruptCheckFrequency(100)`** are now passed to `env.Program()`
+([#923](https://github.com/cert-manager/approver-policy/pull/923)). These
+match the Kubernetes apiextensions-apiserver `PerCallLimit` and
+`CheckFrequency` constants
+([`k8s.io/apiserver/pkg/apis/cel/config.go`](https://github.com/kubernetes/kubernetes/blob/9e570c412469/staging/src/k8s.io/apiserver/pkg/apis/cel/config.go)),
+which are the de facto standard across the ecosystem (also used by Gatekeeper,
+Cluster API, Istio, Cilium, Flux, and Pinniped). The budget of 1,000,000
+abstract cost units corresponds to roughly 0.1 seconds of evaluation time —
+generous for the simple expressions typical of `CertificateRequestPolicy`
+rules.
+
+The original design also noted that "we should probably consider adding some
+cache expiration logic to avoid appearing like a memory leak." The current
+implementation uses a global `sync.Map` with no eviction or expiry — every
+unique expression compiled during the lifetime of the controller remains in
+memory permanently. Cache lifecycle management is tracked separately.

--- a/pkg/internal/approver/validation/validator.go
+++ b/pkg/internal/approver/validation/validator.go
@@ -29,6 +29,24 @@ import (
 const (
 	varSelf    = "self"
 	varRequest = "cr"
+
+	// celCostLimit mirrors the Kubernetes apiextensions-apiserver PerCallLimit,
+	// measured in abstract cost units defined by the CEL cost model (e.g.,
+	// comparisons cost 1, list iteration costs 1 per element, string
+	// operations scale with length). Expressions exceeding this limit are
+	// terminated at runtime with an "actual cost limit exceeded" error
+	// instead of running to completion, preventing a malicious
+	// CertificateRequestPolicy from blocking the single reconcile worker
+	// indefinitely. See CWE-770.
+	// Upstream: https://github.com/kubernetes/kubernetes/blob/9e570c412469/staging/src/k8s.io/apiserver/pkg/apis/cel/config.go#L21
+	celCostLimit = 1000000
+
+	// celInterruptCheckFrequency controls how many comprehension iterations
+	// (.all(), .exists(), .map(), .filter()) elapse between cost-limit
+	// checks. Lower values catch breaches sooner but add overhead; higher
+	// values let the program overshoot the limit before being stopped.
+	// Upstream: https://github.com/kubernetes/kubernetes/blob/9e570c412469/staging/src/k8s.io/apiserver/pkg/apis/cel/config.go#L34
+	celInterruptCheckFrequency = 100
 )
 
 // Validator knows how to validate CSR attribute values in CertificateRequests
@@ -77,7 +95,10 @@ func (v *validator) compile() error {
 			"got %v, wanted %v result type", ast.OutputType(), cel.BoolType)
 	}
 
-	v.program, err = env.Program(ast)
+	v.program, err = env.Program(ast,
+		cel.CostLimit(celCostLimit),
+		cel.InterruptCheckFrequency(celInterruptCheckFrequency),
+	)
 	return err
 }
 

--- a/pkg/internal/approver/validation/validator_test.go
+++ b/pkg/internal/approver/validation/validator_test.go
@@ -91,6 +91,32 @@ func Test_Validator_Validate(t *testing.T) {
 	}
 }
 
+// Test_Validator_Validate_CostLimitExceeded verifies that the CEL runtime
+// cost limit terminates expensive expressions before they hang the reconcile
+// worker. The expression uses 8-deep nested comprehensions (~10^8 iterations).
+//
+// If cel.CostLimit is accidentally removed, this test will hang rather than
+// fail cleanly — that is deliberate: the CI test timeout will catch it, and
+// the resulting stack trace pointing at program.Eval is more diagnostic than
+// a synthetic deadline error.
+func Test_Validator_Validate_CostLimitExceeded(t *testing.T) {
+	v := &validator{expression: `
+		[0,1,2,3,4,5,6,7,8,9].all(a,
+		[0,1,2,3,4,5,6,7,8,9].all(b,
+		[0,1,2,3,4,5,6,7,8,9].all(c,
+		[0,1,2,3,4,5,6,7,8,9].all(d,
+		[0,1,2,3,4,5,6,7,8,9].all(e,
+		[0,1,2,3,4,5,6,7,8,9].all(f,
+		[0,1,2,3,4,5,6,7,8,9].all(g,
+		[0,1,2,3,4,5,6,7,8,9].all(h, self != ""))))))))`}
+	err := v.compile()
+	assert.NoError(t, err, "expression must compile successfully")
+
+	_, err = v.Validate("anything", cmapi.CertificateRequest{})
+	assert.Error(t, err, "evaluation must be terminated by the cost limit")
+	assert.Contains(t, err.Error(), "cost limit exceeded")
+}
+
 func newCertificateRequest(namespace string) cmapi.CertificateRequest {
 	request := cmapi.CertificateRequest{}
 	request.SetNamespace(namespace)


### PR DESCRIPTION
## Summary

- Add `cel.CostLimit(1000000)` and `cel.InterruptCheckFrequency(100)` to CEL
  program options, preventing any single CEL expression from consuming more
  than ~0.1 seconds of CPU time. Expressions exceeding the limit are
  terminated with an "actual cost limit exceeded" error instead of running to
  completion.
- Add an addendum to the CEL design doc recording the change and rationale.

## Motivation

A deeply nested `.all()` comprehension (e.g. 8-deep `[0..9].all(...)` — 10^8
iterations) would hang the single reconcile worker
(`MaxConcurrentReconciles:1`) indefinitely, blocking all certificate approvals
cluster-wide.

`CertificateRequestPolicy` is cluster-scoped and should only be accessible to
admins, so a deliberate DoS is unlikely. However, a cost limit still provides
value as defense-in-depth against accidental complexity — a rule that looks
reasonable can have surprising evaluation cost.

The 1,000,000 cost unit budget is the de facto standard across the Kubernetes
ecosystem — not just the apiserver, but also Gatekeeper, Cluster API, Istio,
Cilium Tetragon, Flux, and Pinniped all use the same value. It corresponds to
roughly 0.1 seconds of evaluation time, which is generous for the simple
expressions typical of CertificateRequestPolicy rules. None of the existing
test expressions come close to hitting it.

## Upstream references

The `PerCallLimit` and `CheckFrequency` constants originate from the
Kubernetes apiextensions-apiserver CEL validation budget:

- kubernetes/kubernetes#108482 — introduced `cel.CostLimit` for CRD CEL validation
- kubernetes/kubernetes#109122 — halved the limits to current values (`PerCallLimit = 1000000`)
- kubernetes/kubernetes#115747 — extracted constants to [`k8s.io/apiserver/pkg/apis/cel/config.go`](https://github.com/kubernetes/kubernetes/blob/9e570c412469/staging/src/k8s.io/apiserver/pkg/apis/cel/config.go)

Other Kubernetes controllers using the same value:
- [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper) — imports `celconfig.PerCallLimit`
- [Cluster API](https://github.com/kubernetes-sigs/cluster-api) — comments: "k/k CRD validation also uses celconfig.PerCallLimit"
- [Istio](https://github.com/istio/istio), [Cilium Tetragon](https://github.com/cilium/tetragon), [Flux](https://github.com/fluxcd/flux2), [Pinniped](https://github.com/vmware-tanzu/pinniped) — all use 1,000,000 / 100

Design context: [KEP for CRD Validation Expression Language](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/2876-crd-validation-expression-language)

Fixes: https://venafi.atlassian.net/browse/VC-53793

## Test plan

- [x] `Test_Validator_Validate_CostLimitExceeded`: compiles the 8-deep nested
  comprehension PoC and verifies `Validate` returns a cost limit error in
  ~0.65s instead of hanging
- [x] All existing tests pass (`go test ./pkg/internal/approver/validation/`)

*Generated with Claude (Opus 4.6)*