### PR TITLE
VC-53793: Add per-CRP lifecycle-bound CEL validator cache

### DIFF
--- a/design/20230726-cel-policy.md
+++ b/design/20230726-cel-policy.md
@@ -479,7 +479,46 @@ generous for the simple expressions typical of `CertificateRequestPolicy`
 rules.
 
 The original design also noted that "we should probably consider adding some
-cache expiration logic to avoid appearing like a memory leak." The current
-implementation uses a global `sync.Map` with no eviction or expiry — every
-unique expression compiled during the lifetime of the controller remains in
-memory permanently. Cache lifecycle management is tracked separately.
+cache expiration logic to avoid appearing like a memory leak." The initial
+implementation used a global `sync.Map` keyed by expression string with no
+eviction or expiry — every unique expression compiled during the lifetime of
+the controller remained in memory permanently.
+
+## Addendum: per-CRP lifecycle-bound validator cache (June 2026)
+
+[#924](https://github.com/cert-manager/approver-policy/pull/924) replaced the
+global expression-keyed cache with a two-level cache keyed by
+`(CertificateRequestPolicy name, expression)`. This ties compiled CEL
+programs to the lifecycle of their owning CRP, mirroring how the Kubernetes
+apiextensions-apiserver stores compiled validators on the
+[`customResourceStrategy`](https://github.com/kubernetes/kubernetes/blob/9e570c412469/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go#L63)
+struct per CRD version.
+
+Cache entries are managed as follows:
+
+- **During evaluation**: `Get(policyName, expression)` compiles on first use and
+  caches the program under the persisted policy's name. This is the only path
+  that populates the cache.
+- **At admission (create/update)**: the webhook `Validate()` calls `Compile`,
+  which checks that each expression compiles **without** caching it, then calls
+  `Remove(policyName)` to drop entries left by the previous generation. Because
+  admission never populates the cache, dry-run and subsequently-rejected
+  requests — which are never persisted and so never receive a delete event —
+  cannot leak entries.
+- **On CRP deletion**: the controller calls `ValidatorCleaner.CleanupValidators`,
+  which removes all cached entries for that policy.
+
+Eviction is **best-effort**. The expression string is part of the cache key, so
+a stale entry can never be returned for the wrong input — correctness never
+depends on eviction; it only bounds memory. In a multi-replica deployment each
+admission request is served by a single replica and the delete reconciler runs
+only on the elected leader, so old entries for an updated or deleted policy may
+linger on other replicas until the process restarts. Steady-state memory is
+therefore bounded by the live policies plus a bounded tail of not-yet-evicted
+entries, rather than growing with every unique expression ever seen as the
+previous global cache did.
+
+A fully replica-complete eviction would require evicting on the delete webhook
+path (which runs on every replica) rather than in the leader-only controller;
+this was judged unnecessary given eviction is correctness-irrelevant and the
+remaining growth is bounded.

--- a/pkg/approver/reconciler.go
+++ b/pkg/approver/reconciler.go
@@ -45,6 +45,20 @@ type ReconcilerReadyResponse struct {
 	ctrl.Result
 }
 
+// ValidatorCleaner is an optional extension that Reconcilers may implement to
+// clean up compiled CEL validators when a CertificateRequestPolicy is deleted.
+// This mirrors the Kubernetes pattern where compiled CEL programs on a
+// customResourceStrategy are torn down when the owning CRD is deleted.
+// See the validation package doc for upstream links.
+//
+// Cleanup is best-effort: the controller invokes it only on the elected leader,
+// so other replicas may retain a deleted policy's entries until restart. This
+// is safe because the compiled-validator cache is keyed by expression as well
+// as policy name, so a stale entry is never returned for the wrong input.
+type ValidatorCleaner interface {
+	CleanupValidators(policyName string)
+}
+
 // Reconciler is responsible for reconciling CertificateRequestPolicies and
 // declaring what state they should be in.
 type Reconciler interface {

--- a/pkg/internal/approver/allowed/allowed.go
+++ b/pkg/internal/approver/allowed/allowed.go
@@ -70,6 +70,12 @@ func (a allowed) Ready(_ context.Context, _ *policyapi.CertificateRequestPolicy)
 	return approver.ReconcilerReadyResponse{Ready: true}, nil
 }
 
+// CleanupValidators removes all cached compiled validators for the named
+// CertificateRequestPolicy.
+func (a allowed) CleanupValidators(policyName string) {
+	a.validators.Remove(policyName)
+}
+
 // allowed never needs to manually enqueue policies.
 func (a allowed) EnqueueChan() <-chan string {
 	return nil

--- a/pkg/internal/approver/allowed/evaluator.go
+++ b/pkg/internal/approver/allowed/evaluator.go
@@ -60,11 +60,12 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 	}
 
 	evaluate := evaluator{
-		a:       a,
-		request: request,
-		csr:     csr,
-		allowed: allowed,
-		fldPath: fldPath,
+		a:          a,
+		policyName: policy.Name,
+		request:    request,
+		csr:        csr,
+		allowed:    allowed,
+		fldPath:    fldPath,
 	}
 	evaluateSubject := evaluate.Subject()
 
@@ -101,19 +102,20 @@ func (a allowed) Evaluate(_ context.Context, policy *policyapi.CertificateReques
 }
 
 type evaluator struct {
-	a       allowed
-	request *cmapi.CertificateRequest
-	csr     *x509.CertificateRequest
-	allowed *policyapi.CertificateRequestPolicyAllowed
-	fldPath *field.Path
+	a          allowed
+	policyName string
+	request    *cmapi.CertificateRequest
+	csr        *x509.CertificateRequest
+	allowed    *policyapi.CertificateRequestPolicyAllowed
+	fldPath    *field.Path
 }
 
 func (e evaluator) CommonName() field.ErrorList {
-	return e.a.evaluateString(e.request, e.csr.Subject.CommonName, e.allowed.CommonName, e.fldPath.Child("commonName"))
+	return e.a.evaluateString(e.policyName, e.request, e.csr.Subject.CommonName, e.allowed.CommonName, e.fldPath.Child("commonName"))
 }
 
 func (e evaluator) DNSNames() field.ErrorList {
-	return e.a.evaluateSlice(e.request, e.csr.DNSNames, e.allowed.DNSNames, e.fldPath.Child("dnsNames"))
+	return e.a.evaluateSlice(e.policyName, e.request, e.csr.DNSNames, e.allowed.DNSNames, e.fldPath.Child("dnsNames"))
 }
 
 func (e evaluator) IPAddresses() field.ErrorList {
@@ -121,7 +123,7 @@ func (e evaluator) IPAddresses() field.ErrorList {
 	for _, ip := range e.csr.IPAddresses {
 		ips = append(ips, ip.String())
 	}
-	return e.a.evaluateSlice(e.request, ips, e.allowed.IPAddresses, e.fldPath.Child("ipAddresses"))
+	return e.a.evaluateSlice(e.policyName, e.request, ips, e.allowed.IPAddresses, e.fldPath.Child("ipAddresses"))
 }
 
 func (e evaluator) URIs() field.ErrorList {
@@ -129,11 +131,11 @@ func (e evaluator) URIs() field.ErrorList {
 	for _, uri := range e.csr.URIs {
 		uris = append(uris, uri.String())
 	}
-	return e.a.evaluateSlice(e.request, uris, e.allowed.URIs, e.fldPath.Child("uris"))
+	return e.a.evaluateSlice(e.policyName, e.request, uris, e.allowed.URIs, e.fldPath.Child("uris"))
 }
 
 func (e evaluator) EmailAddresses() field.ErrorList {
-	return e.a.evaluateSlice(e.request, e.csr.EmailAddresses, e.allowed.EmailAddresses, e.fldPath.Child("emailAddresses"))
+	return e.a.evaluateSlice(e.policyName, e.request, e.csr.EmailAddresses, e.allowed.EmailAddresses, e.fldPath.Child("emailAddresses"))
 }
 
 func (e evaluator) IsCA() field.ErrorList {
@@ -168,55 +170,57 @@ func (e evaluator) Subject() subjectEvaluator {
 		allowed = new(policyapi.CertificateRequestPolicyAllowedX509Subject)
 	}
 	return subjectEvaluator{
-		a:       e.a,
-		request: e.request,
-		sub:     e.csr.Subject,
-		allowed: allowed,
-		fldPath: e.fldPath.Child("subject"),
+		a:          e.a,
+		policyName: e.policyName,
+		request:    e.request,
+		sub:        e.csr.Subject,
+		allowed:    allowed,
+		fldPath:    e.fldPath.Child("subject"),
 	}
 }
 
 type subjectEvaluator struct {
-	a       allowed
-	request *cmapi.CertificateRequest
-	sub     pkix.Name
-	allowed *policyapi.CertificateRequestPolicyAllowedX509Subject
-	fldPath *field.Path
+	a          allowed
+	policyName string
+	request    *cmapi.CertificateRequest
+	sub        pkix.Name
+	allowed    *policyapi.CertificateRequestPolicyAllowedX509Subject
+	fldPath    *field.Path
 }
 
 func (e subjectEvaluator) Organization() field.ErrorList {
-	return e.a.evaluateSlice(e.request, e.sub.Organization, e.allowed.Organizations, e.fldPath.Child("organizations"))
+	return e.a.evaluateSlice(e.policyName, e.request, e.sub.Organization, e.allowed.Organizations, e.fldPath.Child("organizations"))
 }
 
 func (e subjectEvaluator) Country() field.ErrorList {
-	return e.a.evaluateSlice(e.request, e.sub.Country, e.allowed.Countries, e.fldPath.Child("countries"))
+	return e.a.evaluateSlice(e.policyName, e.request, e.sub.Country, e.allowed.Countries, e.fldPath.Child("countries"))
 }
 
 func (e subjectEvaluator) OrganizationalUnit() field.ErrorList {
-	return e.a.evaluateSlice(e.request, e.sub.OrganizationalUnit, e.allowed.OrganizationalUnits, e.fldPath.Child("organizationalUnits"))
+	return e.a.evaluateSlice(e.policyName, e.request, e.sub.OrganizationalUnit, e.allowed.OrganizationalUnits, e.fldPath.Child("organizationalUnits"))
 }
 
 func (e subjectEvaluator) Locality() field.ErrorList {
-	return e.a.evaluateSlice(e.request, e.sub.Locality, e.allowed.Localities, e.fldPath.Child("localities"))
+	return e.a.evaluateSlice(e.policyName, e.request, e.sub.Locality, e.allowed.Localities, e.fldPath.Child("localities"))
 }
 
 func (e subjectEvaluator) Province() field.ErrorList {
-	return e.a.evaluateSlice(e.request, e.sub.Province, e.allowed.Provinces, e.fldPath.Child("provinces"))
+	return e.a.evaluateSlice(e.policyName, e.request, e.sub.Province, e.allowed.Provinces, e.fldPath.Child("provinces"))
 }
 
 func (e subjectEvaluator) StreetAddress() field.ErrorList {
-	return e.a.evaluateSlice(e.request, e.sub.StreetAddress, e.allowed.StreetAddresses, e.fldPath.Child("streetAddresses"))
+	return e.a.evaluateSlice(e.policyName, e.request, e.sub.StreetAddress, e.allowed.StreetAddresses, e.fldPath.Child("streetAddresses"))
 }
 
 func (e subjectEvaluator) PostalCode() field.ErrorList {
-	return e.a.evaluateSlice(e.request, e.sub.PostalCode, e.allowed.PostalCodes, e.fldPath.Child("postalCodes"))
+	return e.a.evaluateSlice(e.policyName, e.request, e.sub.PostalCode, e.allowed.PostalCodes, e.fldPath.Child("postalCodes"))
 }
 
 func (e subjectEvaluator) SerialNumber() field.ErrorList {
-	return e.a.evaluateString(e.request, e.sub.SerialNumber, e.allowed.SerialNumber, e.fldPath.Child("serialNumber"))
+	return e.a.evaluateString(e.policyName, e.request, e.sub.SerialNumber, e.allowed.SerialNumber, e.fldPath.Child("serialNumber"))
 }
 
-func (a allowed) evaluateString(request *cmapi.CertificateRequest, s string, crp *policyapi.CertificateRequestPolicyAllowedString, fldPath *field.Path) field.ErrorList {
+func (a allowed) evaluateString(policyName string, request *cmapi.CertificateRequest, s string, crp *policyapi.CertificateRequestPolicyAllowedString, fldPath *field.Path) field.ErrorList {
 	if len(s) == 0 {
 		// Attribute not set in request. We will only check if it's a required attribute
 		// and not run any validations specified by the policy.
@@ -238,12 +242,12 @@ func (a allowed) evaluateString(request *cmapi.CertificateRequest, s string, crp
 	}
 
 	if len(crp.Validations) > 0 {
-		el = append(el, a.runValidations(request, crp.Validations, s, fldPath.Child("validations"))...)
+		el = append(el, a.runValidations(policyName, request, crp.Validations, s, fldPath.Child("validations"))...)
 	}
 	return el
 }
 
-func (a allowed) evaluateSlice(request *cmapi.CertificateRequest, s []string, crp *policyapi.CertificateRequestPolicyAllowedStringSlice, fldPath *field.Path) field.ErrorList {
+func (a allowed) evaluateSlice(policyName string, request *cmapi.CertificateRequest, s []string, crp *policyapi.CertificateRequestPolicyAllowedStringSlice, fldPath *field.Path) field.ErrorList {
 	if len(s) == 0 {
 		// Attribute not set in request. We will only check if it's a required attribute
 		// and not run any validations specified by the policy.
@@ -267,7 +271,7 @@ func (a allowed) evaluateSlice(request *cmapi.CertificateRequest, s []string, cr
 	if len(crp.Validations) > 0 {
 		fldPath := fldPath.Child("validations")
 		for _, v := range s {
-			el = append(el, a.runValidations(request, crp.Validations, v, fldPath)...)
+			el = append(el, a.runValidations(policyName, request, crp.Validations, v, fldPath)...)
 		}
 	}
 	return el
@@ -285,10 +289,10 @@ func (a allowed) evaluateBool(b bool, crp *bool, fldPath *field.Path) field.Erro
 	return el
 }
 
-func (a allowed) runValidations(request *cmapi.CertificateRequest, validations []policyapi.ValidationRule, s string, fldPath *field.Path) field.ErrorList {
+func (a allowed) runValidations(policyName string, request *cmapi.CertificateRequest, validations []policyapi.ValidationRule, s string, fldPath *field.Path) field.ErrorList {
 	var el field.ErrorList
 	for i, v := range validations {
-		validator, err := a.validators.Get(v.Rule)
+		validator, err := a.validators.Get(policyName, v.Rule)
 		if err != nil {
 			el = append(el, field.InternalError(fldPath.Index(i), err))
 			continue

--- a/pkg/internal/approver/allowed/validation.go
+++ b/pkg/internal/approver/allowed/validation.go
@@ -36,6 +36,17 @@ func (a allowed) Validate(_ context.Context, policy *policyapi.CertificateReques
 		}, nil
 	}
 
+	// On CREATE/UPDATE, discard any validators cached under this policy name by
+	// a previous generation so an updated CRP does not retain compiled programs
+	// for expressions it no longer declares. The expressions below are checked
+	// with Compile (not Get) so this admission path never repopulates the
+	// lifecycle cache: a dry-run or subsequently-rejected request must not leave
+	// entries behind. The cache is repopulated lazily during evaluation of the
+	// persisted policy. Remove is best-effort per replica (see the cache docs).
+	if policy.Name != "" {
+		a.validators.Remove(policy.Name)
+	}
+
 	var (
 		el      field.ErrorList
 		allowed = policy.Spec.Allowed
@@ -83,7 +94,7 @@ func (a allowed) Validate(_ context.Context, policy *policyapi.CertificateReques
 				}
 			}
 			for i, validation := range stringSlice.slice.Validations {
-				if _, err := a.validators.Get(validation.Rule); err != nil {
+				if _, err := a.validators.Compile(validation.Rule); err != nil {
 					el = append(el, field.Invalid(stringSlice.path.Child("validations").Index(i), validation.Rule, err.Error()))
 				}
 			}
@@ -98,7 +109,7 @@ func (a allowed) Validate(_ context.Context, policy *policyapi.CertificateReques
 				}
 			}
 			for i, validation := range stringI.string.Validations {
-				if _, err := a.validators.Get(validation.Rule); err != nil {
+				if _, err := a.validators.Compile(validation.Rule); err != nil {
 					el = append(el, field.Invalid(stringI.path.Child("validations").Index(i), validation.Rule, err.Error()))
 				}
 			}

--- a/pkg/internal/approver/validation/cache.go
+++ b/pkg/internal/approver/validation/cache.go
@@ -16,24 +16,49 @@ limitations under the License.
 
 package validation
 
-import "sync"
+import (
+	"sync"
+)
 
-// Cache maintains a cache of compiled validators.
-// The current implementation is a simple lazy cache meaning:
+// Cache maintains compiled CEL validators keyed by CertificateRequestPolicy
+// name and expression string, analogous to how the Kubernetes
+// apiextensions-apiserver ties compiled validators to the CRD
+// customResourceStrategy (see package doc for details and upstream links).
 //
-// 1. Whenever a validator is requested, it first checks the cache.
-// 2. If a compiled validator exists for the supplied CEL expression, it is returned.
-// 3. If the validator doesn't exist in the cache, a new validator is created, compiled, added to the cache, and returned.
+// Compiled programs are tied to the CRP lifecycle: populated on demand during
+// evaluation via [Cache.Get] and discarded via [Cache.Remove] when the CRP is
+// updated or deleted. Eviction is best-effort: because the expression string
+// is part of the cache key, a stale entry can never be returned for the wrong
+// input, so correctness never depends on it — Remove only bounds memory.
+//
+// CertificateRequestPolicy is cluster-scoped so the name is globally unique.
 type Cache interface {
-	// Get returns a compiled validator for the supplied CEL expression.
-	// Any compilation errors will be returned to the caller.
-	//
-	// The supplied CEL expression must output a bool.
-	Get(expr string) (Validator, error)
+	// Get returns a compiled validator for the given CEL expression, cached
+	// for the lifetime of the named CertificateRequestPolicy. policyName must
+	// be non-empty; callers that only need to check whether an expression
+	// compiles, without retaining it, should use [Cache.Compile] instead.
+	Get(policyName string, expr string) (Validator, error)
+
+	// Compile compiles the CEL expression and returns the validator without
+	// caching it. It is used for admission-time validity checks, where the
+	// result is transient and must not grow the lifecycle cache — for example
+	// dry-run or rejected CREATE requests, which are never persisted and so
+	// would otherwise leak entries that no delete event ever cleans up.
+	Compile(expr string) (Validator, error)
+
+	// Remove discards all compiled validators for the named
+	// CertificateRequestPolicy. It is best-effort memory cleanup (see the type
+	// documentation); correctness does not depend on it.
+	Remove(policyName string)
 }
 
 type cache struct {
-	m sync.Map
+	m sync.Map // string (CRP name) -> *crpEntry
+}
+
+type crpEntry struct {
+	mu         sync.Mutex
+	validators map[string]*cacheEntry
 }
 
 type cacheEntry struct {
@@ -41,26 +66,43 @@ type cacheEntry struct {
 	err       error
 }
 
-func (c *cache) Get(expr string) (Validator, error) {
-	// First check if cache contains validator for expression
-	o, ok := c.m.Load(expr)
-	if ok {
-		ce := o.(*cacheEntry)
-		return ce.validator, ce.err
+func (c *cache) Compile(expr string) (Validator, error) {
+	v := &validator{expression: expr}
+	if err := v.compile(); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (c *cache) Get(policyName string, expr string) (Validator, error) {
+	// Load before LoadOrStore so the common cache-hit path does not allocate a
+	// throwaway crpEntry (and its map) on every call.
+	entry, ok := c.m.Load(policyName)
+	if !ok {
+		entry, _ = c.m.LoadOrStore(policyName, &crpEntry{
+			validators: make(map[string]*cacheEntry),
+		})
+	}
+	ce := entry.(*crpEntry)
+
+	ce.mu.Lock()
+	defer ce.mu.Unlock()
+
+	if cached, ok := ce.validators[expr]; ok {
+		return cached.validator, cached.err
 	}
 
-	// Expression did not exist in cache. Create a new validator, compile it
-	// and add the result to cache.
-	// Theoretically this could lead to the same expression being compiled multiple times,
-	// but guarding against that would require locking and increase complexity.
 	v := &validator{expression: expr}
 	err := v.compile()
 	if err != nil {
 		v = nil
 	}
-	o, _ = c.m.LoadOrStore(expr, &cacheEntry{validator: v, err: err})
-	ce := o.(*cacheEntry)
-	return ce.validator, ce.err
+	ce.validators[expr] = &cacheEntry{validator: v, err: err}
+	return v, err
+}
+
+func (c *cache) Remove(policyName string) {
+	c.m.Delete(policyName)
 }
 
 // NewCache is a constructor for cache of compiled CEL expression validators.

--- a/pkg/internal/approver/validation/cache_test.go
+++ b/pkg/internal/approver/validation/cache_test.go
@@ -22,35 +22,151 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Test_Cache_Get verifies that valid expressions are compiled and cached (same
+// pointer on repeated Get), and that invalid expressions return a cached error.
 func Test_Cache_Get(t *testing.T) {
 	c := NewCache()
 
 	type args struct {
-		expr string
+		policyName string
+		expr       string
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 	}{
-		{name: "valid-expression", args: args{expr: "self.endsWith(cr.namespace + '.svc')"}},
-		{name: "invalid-expression", args: args{expr: "foo"}, wantErr: true},
+		{name: "valid-expression", args: args{policyName: "policy-1", expr: "self.endsWith(cr.namespace + '.svc')"}},
+		{name: "invalid-expression", args: args{policyName: "policy-1", expr: "foo"}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.Get(tt.args.expr)
+			got, err := c.Get(tt.args.policyName, tt.args.expr)
 
 			if tt.wantErr {
 				assert.Error(t, err)
-				// Cache should return same error for same expression
-				_, sameErr := c.Get(tt.args.expr)
+				_, sameErr := c.Get(tt.args.policyName, tt.args.expr)
 				assert.Same(t, err, sameErr)
 			} else {
 				assert.NoError(t, err)
-				// Cache should return same validator for same expression
-				same, _ := c.Get(tt.args.expr)
+				same, _ := c.Get(tt.args.policyName, tt.args.expr)
 				assert.Same(t, got, same)
 			}
 		})
 	}
+}
+
+// Test_Cache_Compile verifies that Compile returns a validator (or error)
+// without caching: repeated calls for the same expression return distinct
+// validators, and a compile error is returned directly rather than stored.
+// This is the admission-time path that must not grow the lifecycle cache for
+// dry-run or rejected requests.
+func Test_Cache_Compile(t *testing.T) {
+	c := NewCache()
+
+	v1, err := c.Compile("self == 'test'")
+	assert.NoError(t, err)
+	assert.NotNil(t, v1)
+
+	v2, err := c.Compile("self == 'test'")
+	assert.NoError(t, err)
+	assert.NotNil(t, v2)
+
+	assert.NotSame(t, v1, v2, "Compile must not cache: each call returns a fresh validator")
+
+	v, err := c.Compile("foo")
+	assert.Error(t, err)
+	assert.Nil(t, v, "Compile must return a nil validator on compilation error")
+}
+
+// Test_Cache_Compile_DoesNotPopulate verifies that Compile does not leave an
+// entry that a later Get would return, so admission-time validity checks never
+// populate the lifecycle cache.
+func Test_Cache_Compile_DoesNotPopulate(t *testing.T) {
+	c := NewCache()
+
+	compiled, err := c.Compile("self == 'x'")
+	assert.NoError(t, err)
+
+	got, err := c.Get("policy-1", "self == 'x'")
+	assert.NoError(t, err)
+
+	assert.NotSame(t, compiled, got, "Get after Compile must compile a fresh, cached validator")
+}
+
+// Test_Cache_Get_IsolatedByOwner verifies that the same expression compiled
+// under different CRP owners produces separate cache entries, so that removing
+// one owner's validators does not affect another's.
+func Test_Cache_Get_IsolatedByOwner(t *testing.T) {
+	c := NewCache()
+
+	v1, err := c.Get("policy-a", "self == 'x'")
+	assert.NoError(t, err)
+
+	v2, err := c.Get("policy-b", "self == 'x'")
+	assert.NoError(t, err)
+
+	assert.NotSame(t, v1, v2, "same expression under different owners must produce separate entries")
+}
+
+// Test_Cache_Remove verifies that Remove discards all cached validators for
+// an owner, so that a subsequent Get compiles a fresh validator rather than
+// returning the stale one. This is the mechanism used on CRP deletion.
+func Test_Cache_Remove(t *testing.T) {
+	c := NewCache()
+
+	v1, err := c.Get("policy-1", "self == 'x'")
+	assert.NoError(t, err)
+
+	c.Remove("policy-1")
+
+	v2, err := c.Get("policy-1", "self == 'x'")
+	assert.NoError(t, err)
+
+	assert.NotSame(t, v1, v2, "after Remove, a fresh validator must be compiled")
+}
+
+// Test_Cache_Remove_OnlyAffectsTarget verifies that removing one owner's
+// validators leaves other owners' cached validators intact.
+func Test_Cache_Remove_OnlyAffectsTarget(t *testing.T) {
+	c := NewCache()
+
+	vA, err := c.Get("policy-a", "self == 'x'")
+	assert.NoError(t, err)
+
+	_, err = c.Get("policy-b", "self == 'y'")
+	assert.NoError(t, err)
+
+	c.Remove("policy-b")
+
+	vA2, err := c.Get("policy-a", "self == 'x'")
+	assert.NoError(t, err)
+
+	assert.Same(t, vA, vA2, "Remove must not affect other owners")
+}
+
+// Test_Cache_Remove_ThenRepopulate simulates a CRP update: the webhook clears
+// the cache via Remove and recompiles only the current expressions. After
+// Remove, a subsequent Get for the same expression must return a new validator
+// (not the previously cached one), confirming the old entry was discarded.
+func Test_Cache_Remove_ThenRepopulate(t *testing.T) {
+	c := NewCache()
+
+	// Populate the cache with two expressions, as if the original CRP had both.
+	v1a, err := c.Get("policy-1", "self == 'a'")
+	assert.NoError(t, err)
+	// Expression 'b' represents a rule that will be removed in the updated CRP.
+	_, err = c.Get("policy-1", "self == 'b'")
+	assert.NoError(t, err)
+
+	// Simulate CRP update: webhook calls Remove before recompiling.
+	c.Remove("policy-1")
+
+	// Re-populate with only expression 'a', as if the updated CRP dropped 'b'.
+	v1aNew, err := c.Get("policy-1", "self == 'a'")
+	assert.NoError(t, err)
+
+	// NotSame asserts the two values have different pointer addresses,
+	// proving a fresh validator was compiled rather than returning the old one.
+	assert.NotSame(t, v1a, v1aNew, "after Remove+re-Get, validator must be freshly compiled")
 }

--- a/pkg/internal/approver/validation/doc.go
+++ b/pkg/internal/approver/validation/doc.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package validation compiles and evaluates CEL expressions used in
+// CertificateRequestPolicy validation rules.
+//
+// # Design
+//
+// Compiled CEL programs are stored in a [Cache] keyed by
+// CertificateRequestPolicy name and expression string. Programs for a given
+// policy are discarded when the policy is deleted, bounding memory to the
+// number of persisted policies.
+//
+// This lifecycle-bound approach mirrors how the Kubernetes
+// apiextensions-apiserver manages compiled CEL validators for CustomResourceDefinitions:
+//
+//   - Each CRD version has a [customResourceStrategy] that holds a tree of
+//     compiled CEL [Validator] structs (via [cel.NewValidator]), stored as
+//     struct fields rather than in a separate cache.
+//   - The strategy is [constructed] when a CRD is created or updated, and
+//     garbage-collected when the CRD is deleted.
+//   - The number of compiled programs is therefore naturally bounded by the
+//     number of CRDs in the cluster.
+//
+// approver-policy differs in that CEL expressions are opaque string values
+// inside CertificateRequestPolicy custom resources, not part of a CRD schema.
+// The controller compiles them lazily on first encounter rather than eagerly
+// at CRP create/update time. However, the lifecycle-bound storage principle
+// is the same: compiled programs are owned by their CRP and cleaned up on
+// deletion.
+//
+// The lifecycle cache is populated only while evaluating CertificateRequests
+// against a persisted policy, keyed by (policy name, expression). The admission
+// webhook instead uses [Cache.Compile], which checks that an expression
+// compiles without storing it, so requests that are never persisted — dry-run
+// or subsequently-rejected CREATEs — cannot leave behind entries that no delete
+// event would ever clean up. This closes the unbounded-growth vector that
+// motivated the design. See CWE-770.
+//
+// Eviction (on CRP update via the webhook, on CRP delete via the controller)
+// is best-effort: because the expression string is part of the cache key, a
+// stale entry can never be returned for the wrong input, so correctness never
+// depends on eviction. In a multi-replica deployment each admission request is
+// served by a single replica and the delete reconciler runs only on the
+// elected leader, so a deleted or updated policy's old entries may linger on
+// other replicas until the process restarts. Steady-state memory is therefore
+// bounded by the live policies plus a bounded tail of not-yet-evicted entries,
+// rather than growing without limit as the previous global cache did.
+//
+// [customResourceStrategy]: https://github.com/kubernetes/kubernetes/blob/9e570c412469/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go#L63
+// [Validator]: https://github.com/kubernetes/kubernetes/blob/9e570c412469/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go#L84
+// [cel.NewValidator]: https://github.com/kubernetes/kubernetes/blob/9e570c412469/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel/validation.go#L108
+// [constructed]: https://github.com/kubernetes/kubernetes/blob/9e570c412469/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go#L835
+package validation

--- a/pkg/internal/controllers/certificaterequestpolicies.go
+++ b/pkg/internal/controllers/certificaterequestpolicies.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -167,7 +168,21 @@ func (c *certificaterequestpolicies) reconcileStatusPatch(ctx context.Context, r
 
 	policy := new(policyapi.CertificateRequestPolicy)
 	if err := c.client.Get(ctx, req.NamespacedName, policy); err != nil {
-		return reconcile.Result{}, nil, client.IgnoreNotFound(err)
+		if apierrors.IsNotFound(err) {
+			// The policy has been deleted: drop any compiled validators cached
+			// under its name. This reconciler runs only on the elected leader,
+			// so this cleanup is best-effort per replica — other replicas may
+			// retain the entries until restart. That is acceptable because the
+			// expression is part of the cache key, so a stale entry is never
+			// returned for the wrong input; eviction only bounds memory.
+			for _, reconciler := range c.reconcilers {
+				if cleaner, ok := reconciler.(approver.ValidatorCleaner); ok {
+					cleaner.CleanupValidators(req.Name)
+				}
+			}
+			return reconcile.Result{}, nil, nil
+		}
+		return reconcile.Result{}, nil, err
 	}
 
 	var (


### PR DESCRIPTION
## Summary

- Key compiled CEL validators by `(CertificateRequestPolicy name, expression)`,
  scoping cached programs to their owning policy.
- Populate the cache only when evaluating CertificateRequests against a
  persisted policy (`Cache.Get`). The admission webhook uses `Cache.Compile`,
  which checks that an expression compiles **without** caching it, so dry-run
  or subsequently-rejected requests — never persisted, so never cleaned up by a
  delete event — cannot leak entries.
- Discard a CRP's cached validators when it is deleted (via the
  `ValidatorCleaner` interface) and at the start of webhook `Validate()` on
  update.

## Motivation

The CEL validator cache uses a global `sync.Map` keyed by expression string
with no eviction — every unique expression compiled during the controller's
lifetime remains in memory permanently. The [CEL design doc](design/20230726-cel-policy.md)
flagged this: "we should probably consider adding some cache expiration logic
to avoid appearing like a memory leak."

This PR ties cache lifetime to the CRP lifecycle, analogous to how the
Kubernetes apiextensions-apiserver ties compiled CEL validators to the CRD
[`customResourceStrategy`](https://github.com/kubernetes/kubernetes/blob/9e570c412469/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go#L63)
struct. See the `doc.go` file for detailed upstream links.

## Design

| Aspect | Before (global cache) | After (per-CRP lifecycle) |
|---|---|---|
| Key | Expression string | (CRP name, expression) |
| Eviction | None | On CRP delete or update (best-effort) |
| Admission checks | Cached permanently | Compiled, not stored (`Cache.Compile`) |
| Memory bound | Unbounded | Live policies + bounded eviction tail |
| Deduplication | Shared across CRPs | Compiled per CRP |

Losing expression deduplication across CRPs is acceptable — CRPs are
admin-managed, low-churn resources, and the number of unique expressions per
cluster is small.

Eviction is **best-effort and correctness-independent**: because the expression
string is part of the cache key, a lookup only ever returns the validator for
that exact expression, so a stale entry is never returned for the wrong input.
In a multi-replica deployment the webhook `Remove` runs only on the replica that
served the admission and delete cleanup runs only on the leader, so other
replicas may retain old entries until restart — a bounded memory cost, never a
wrong-answer risk.

Fixes: https://venafi.atlassian.net/browse/VC-53793

## Test plan

- [x] `Test_Cache_Get`: basic caching and error caching, scoped by policy name
- [x] `Test_Cache_Compile`: `Compile` returns a validator (or error) without
  caching — repeated calls yield distinct validators
- [x] `Test_Cache_Compile_DoesNotPopulate`: a later `Get` does not see anything
  left by `Compile`, so admission never populates the lifecycle cache
- [x] `Test_Cache_Get_IsolatedByOwner`: same expression under different owners
  produces separate entries
- [x] `Test_Cache_Remove`: after Remove, Get compiles a fresh validator
- [x] `Test_Cache_Remove_OnlyAffectsTarget`: Remove does not affect other
  owners
- [x] `Test_Cache_Remove_ThenRepopulate`: simulates CRP update — Remove clears
  old entries, subsequent Get compiles fresh
- [x] `make test` and `verify-golangci-lint` pass locally; all existing tests
  pass

*Generated with Claude (Opus 4.8)*
