### PR TITLE
VC-53793: Replace recursive wildcard matching with iterative algorithm

### DIFF
--- a/pkg/internal/util/wildcard.go
+++ b/pkg/internal/util/wildcard.go
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 // !!
-// Modified from https://github.com/minio/minio/blob/RELEASE.2020-06-22T03-12-50Z.hotfix/pkg/wildcard/match.go
+// Originally adapted from minio's wildcard matcher (minio/minio, now archived):
+// https://github.com/minio/minio/blob/RELEASE.2020-06-22T03-12-50Z/pkg/wildcard/match.go
+//
+// matchRunes (below) has since been rewritten to an iterative algorithm and is
+// intentionally not a drop-in copy of the version now maintained at
+// https://github.com/minio/pkg/blob/main/wildcard/match.go: that one is still
+// recursive, and unlike minio we support only '*' (not '?') and match on runes
+// rather than bytes. Prefer not to re-sync from upstream.
 
 package util
 
@@ -65,27 +72,47 @@ func WildcardMatches(pattern, str string) bool {
 	return matchRunes([]rune(pattern), []rune(str))
 }
 
-// matchRunes will return whether the given rune slice matches the given
-// pattern using wildcards ('*').
+// matchRunes returns whether str matches pattern using '*' wildcards.
+// It uses an iterative backtrack-checkpoint algorithm that runs in O(n*m)
+// time, replacing the original recursive implementation which was O(2^n)
+// with multiple wildcards. See CWE-770.
+//
+// This is the standard greedy wildcard matcher: on each '*' we record a single
+// checkpoint (starPx/starSx) and, on a later mismatch, rewind str one past that
+// checkpoint rather than forking into two recursive calls. Only the most recent
+// '*' needs remembering. The same technique backs Go's path/filepath.Match,
+// glibc's glob(3) and many other production matchers. References:
+//   - Russ Cox, "Glob Matching Can Be Simple And Fast Too" https://research.swtch.com/glob
+//   - https://en.wikipedia.org/wiki/Matching_wildcards (non-recursive section)
 func matchRunes(pattern, str []rune) bool {
-	for len(pattern) > 0 {
-		switch pattern[0] {
+	px, sx := 0, 0
+	starPx, starSx := -1, -1
 
-		// If '*' then branch with recursive check for before and after '*'
-		case '*':
-			return matchRunes(pattern[1:], str) || (len(str) > 0 && matchRunes(pattern, str[1:]))
-
-		// If still strings to match or patter and string don't match at index, no match.
+	for sx < len(str) {
+		switch {
+		case px < len(pattern) && pattern[px] == '*':
+			// Record a checkpoint at the '*' and try to match it against the
+			// empty string first.
+			starPx, starSx = px, sx
+			px++
+		case px < len(pattern) && pattern[px] == str[sx]:
+			// Literal match; advance both positions.
+			px++
+			sx++
+		case starPx >= 0:
+			// Mismatch, but a '*' is still open: backtrack to it and let it
+			// consume one more character of str.
+			starSx++
+			sx = starSx
+			px = starPx + 1
 		default:
-			if len(str) == 0 || str[0] != pattern[0] {
-				return false
-			}
+			// Mismatch with no '*' to fall back on.
+			return false
 		}
-
-		str = str[1:]
-		pattern = pattern[1:]
 	}
 
-	// If both empty, then match
-	return len(str) == 0 && len(pattern) == 0
+	for px < len(pattern) && pattern[px] == '*' {
+		px++
+	}
+	return px == len(pattern)
 }

--- a/pkg/internal/util/wildcard_test.go
+++ b/pkg/internal/util/wildcard_test.go
@@ -18,7 +18,9 @@ package util
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 )
 
 func Test_WildcardSubset(t *testing.T) {
@@ -302,5 +304,31 @@ func Test_WildcardMatches(t *testing.T) {
 					test.pattern, test.text, test.exp, match)
 			}
 		})
+	}
+}
+
+// Test_WildcardMatches_BacktrackingDoesNotHang verifies that patterns with
+// multiple wildcards do not cause exponential backtracking. The pattern
+// "*a*a*a*a*a*a*a*a*!" against a string of 50 'a' characters would explore
+// ~2^50 branches with the old recursive algorithm; the iterative replacement
+// handles it in O(n*m). If the iterative algorithm is accidentally reverted,
+// the call below will not return and the bounded select fails the test with an
+// actionable message, rather than hanging until the global test timeout fires.
+func Test_WildcardMatches_BacktrackingDoesNotHang(t *testing.T) {
+	// 8 wildcards interleaved with 'a', ending in '!' which never appears
+	// in the input string — forces full exploration of every branch.
+	pattern := "*a*a*a*a*a*a*a*a*!"
+	str := strings.Repeat("a", 50)
+
+	done := make(chan bool, 1)
+	go func() { done <- WildcardMatches(pattern, str) }()
+
+	select {
+	case match := <-done:
+		if match {
+			t.Errorf("expected no match for pattern %q against %q", pattern, str)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("WildcardMatches(%q, ...) did not return within 5s; exponential backtracking has regressed", pattern)
 	}
 }


### PR DESCRIPTION
## Summary

- Replace recursive `matchRunes` with an iterative backtrack-checkpoint algorithm that runs in O(n*m), fixing exponential backtracking with multiple wildcards
- Add `Test_WildcardMatches_BacktrackingDoesNotHang` regression test

## Motivation

This hardens approver-policy against [CWE-770](https://cwe.mitre.org/data/definitions/770.html) (allocation of resources without limits or throttling). A security assessment identified two DoS variants in approver-policy:

1. **CEL comprehension DoS** — fixed in cert-manager/approver-policy#923
2. **Wildcard backtracking DoS** — fixed in this PR

The `matchRunes` function (originally adapted from [minio](https://github.com/minio/minio/blob/RELEASE.2020-06-22T03-12-50Z/pkg/wildcard/match.go)) used recursive backtracking to match `*` wildcards. With multiple wildcards in a pattern (e.g. `*a*a*a*a*a*a*a*a*!`), the worst case is O(2^n) — a pattern with 8 wildcards against a 50-character string explores ~2^50 branches, hanging the reconcile worker indefinitely.

The exponential cost is driven by the number of `*` in the **pattern**, which comes from a `CertificateRequestPolicy` (`allowed.*.values` and `selector.issuerRef` fields) — a privileged, cluster-scoped resource. The realistic risk is therefore an administrator **inadvertently** configuring a pathological pattern, rather than an attacker authoring a malicious CRP. Note the matched string comes from `CertificateRequest`s (a far less privileged, namespaced operation), so once such a pattern exists, a low-privileged requester can supply crafted values that hit the worst case — escalating a misconfiguration into a cluster-wide approval DoS.

The fix replaces the recursive algorithm with an iterative "backtrack checkpoint" technique: when a `*` is encountered, the pattern and string positions are recorded as a checkpoint. On mismatch, execution backtracks to the checkpoint (advancing the string position by one) instead of forking into two recursive branches.

## Correctness / prior art

This is not a bespoke algorithm — it is the standard **greedy wildcard matcher with a single backtracking checkpoint** (the "two-pointer" linear glob matcher). On each `*` we record only the most recent checkpoint (`starPx`/`starSx`) and, on a later mismatch, rewind the text pointer one past that checkpoint rather than forking. It runs in O(n*m); only the most recent `*` ever needs remembering.

References that establish correctness and the security motivation:

- **Russ Cox, ["Glob Matching Can Be Simple And Fast Too"](https://research.swtch.com/glob)** — presents the same checkpoint algorithm, explains why recursive matching is exponential (`n^e` for `e` stars), and frames it as a DoS class with real CVEs (CVE-2001-1501, CVE-2010-2632). Notes the same technique backs Go's `path/filepath.Match`, glibc's `glob(3)` and vsftpd.
- **Wikipedia, ["Matching wildcards"](https://en.wikipedia.org/wiki/Matching_wildcards)** (non-recursive section) — "only one such saved set [of pointers] is needed since just one successful match is required"; attributes iterative implementations to Dogan Kurt and Kirk J. Krauss (Dr. Dobb's, 2008).
- **[LeetCode #44 "Wildcard Matching"](https://leetcode.com/problems/wildcard-matching/)** — the canonical accepted O(m·n) greedy solution is structurally identical to this implementation.

**Note on upstream minio:** minio never fixed this. Both the originally-copied version and the current [`minio/pkg`](https://github.com/minio/pkg/blob/master/wildcard/match.go) still use recursive backtracking and remain vulnerable. We deliberately diverge: unlike minio we support only `*` (not `?`) and match on runes rather than bytes, so this matcher should **not** be re-synced from upstream. This is documented in the file header.

## Test plan

- [x] All existing `Test_WildcardSubset`, `Test_WildcardContains`, `Test_WildcardMatches` tests pass — the fix is internal to `matchRunes` only
- [x] `Test_WildcardMatches_BacktrackingDoesNotHang` completes instantly and fails fast (bounded 5s `select`) if the exponential algorithm is ever reinstated, rather than hanging until the global CI timeout
- [x] `make verify` passes (incl. `golangci-lint`)

*Generated with Claude (Opus 4.8)*
