### PR TITLE
VC-53793: Bound the CEL validator cache with an LRU (alternative to #924)

### DIFF
--- a/design/20230726-cel-policy.md
+++ b/design/20230726-cel-policy.md
@@ -479,7 +479,31 @@ generous for the simple expressions typical of `CertificateRequestPolicy`
 rules.
 
 The original design also noted that "we should probably consider adding some
-cache expiration logic to avoid appearing like a memory leak." The current
-implementation uses a global `sync.Map` with no eviction or expiry — every
-unique expression compiled during the lifetime of the controller remains in
-memory permanently. Cache lifecycle management is tracked separately.
+cache expiration logic to avoid appearing like a memory leak." The initial
+implementation used a global `sync.Map` keyed by expression string with no
+eviction or expiry — every unique expression compiled during the lifetime of
+the controller remained in memory permanently.
+
+## Addendum: bounded (LRU) validator cache (June 2026)
+
+[#926](https://github.com/cert-manager/approver-policy/pull/926) replaced the
+unbounded global `sync.Map` with a fixed-size least-recently-used cache
+(`k8s.io/utils/lru`, already in the dependency tree), holding at most
+`DefaultCacheSize` (1024) compiled programs. When the limit is exceeded the
+least-recently-used entry is evicted.
+
+This directly closes the memory-exhaustion variant of
+[VC-53793](https://venafi.atlassian.net/browse/VC-53793) (CWE-770): a principal
+able to author policies — including via dry-run CREATEs that are never
+persisted — can no longer grow controller memory without bound by submitting
+unique large expressions, because the cache size is capped regardless of input.
+
+A bounded cache was chosen over tying entries to the CertificateRequestPolicy
+lifecycle because it keeps the cache a self-contained concern. It needs no
+knowledge of policy creation, update or deletion, no controller or webhook
+plumbing, and no per-replica eviction coordination; an entry for a deleted or
+rewritten policy simply ages out. The only trade-off is that, under a flood of
+unique expressions, a legitimate policy's compiled program may be evicted and
+recompiled on next use — a bounded, low cost, and one already capped per
+compilation by the CEL cost limit added in
+[#923](https://github.com/cert-manager/approver-policy/pull/923).

--- a/pkg/internal/approver/validation/cache.go
+++ b/pkg/internal/approver/validation/cache.go
@@ -16,14 +16,30 @@ limitations under the License.
 
 package validation
 
-import "sync"
+import "k8s.io/utils/lru"
 
-// Cache maintains a cache of compiled validators.
-// The current implementation is a simple lazy cache meaning:
+// DefaultCacheSize is the maximum number of compiled CEL validators held by a
+// Cache before the least-recently-used entry is evicted.
 //
-// 1. Whenever a validator is requested, it first checks the cache.
-// 2. If a compiled validator exists for the supplied CEL expression, it is returned.
-// 3. If the validator doesn't exist in the cache, a new validator is created, compiled, added to the cache, and returned.
+// CertificateRequestPolicy resources are admin-managed and low-churn, so the
+// number of distinct expressions in any real cluster is small; this bound
+// exists only to cap memory under adversarial input (CWE-770), where a
+// principal able to author policies — including via dry-run requests that are
+// never persisted — could otherwise submit unbounded unique expressions.
+const DefaultCacheSize = 1024
+
+// Cache maintains a bounded, lazily-populated cache of compiled validators.
+// The implementation is a simple LRU cache meaning:
+//
+//  1. Whenever a validator is requested, it first checks the cache.
+//  2. If a compiled validator exists for the supplied CEL expression, it is returned.
+//  3. Otherwise a new validator is created, compiled, added to the cache, and returned.
+//
+// The cache holds at most [DefaultCacheSize] entries; the least-recently-used
+// entry is evicted when that limit is exceeded. Bounding the size — rather than
+// tying entries to policy lifecycle — keeps the cache a self-contained concern:
+// it needs no knowledge of CertificateRequestPolicy creation, update or
+// deletion, and an entry for a deleted or rewritten policy simply ages out.
 type Cache interface {
 	// Get returns a compiled validator for the supplied CEL expression.
 	// Any compilation errors will be returned to the caller.
@@ -33,7 +49,8 @@ type Cache interface {
 }
 
 type cache struct {
-	m sync.Map
+	// lru is safe for concurrent use; it guards its own state with a mutex.
+	lru *lru.Cache
 }
 
 type cacheEntry struct {
@@ -42,28 +59,36 @@ type cacheEntry struct {
 }
 
 func (c *cache) Get(expr string) (Validator, error) {
-	// First check if cache contains validator for expression
-	o, ok := c.m.Load(expr)
-	if ok {
+	// First check if cache contains a validator for the expression.
+	if o, ok := c.lru.Get(expr); ok {
 		ce := o.(*cacheEntry)
 		return ce.validator, ce.err
 	}
 
 	// Expression did not exist in cache. Create a new validator, compile it
-	// and add the result to cache.
-	// Theoretically this could lead to the same expression being compiled multiple times,
-	// but guarding against that would require locking and increase complexity.
+	// and add the result to the cache (including a compilation error, so
+	// invalid expressions are not recompiled on every request).
+	// Theoretically this could lead to the same expression being compiled
+	// multiple times, but guarding against that would require locking and
+	// increase complexity.
 	v := &validator{expression: expr}
 	err := v.compile()
 	if err != nil {
 		v = nil
 	}
-	o, _ = c.m.LoadOrStore(expr, &cacheEntry{validator: v, err: err})
-	ce := o.(*cacheEntry)
-	return ce.validator, ce.err
+	c.lru.Add(expr, &cacheEntry{validator: v, err: err})
+	return v, err
 }
 
-// NewCache is a constructor for cache of compiled CEL expression validators.
+// NewCache is a constructor for a bounded cache of compiled CEL expression
+// validators, holding at most [DefaultCacheSize] entries.
 func NewCache() Cache {
-	return &cache{}
+	return newCache(DefaultCacheSize)
+}
+
+// newCache constructs a cache bounded to size entries. Exposed separately from
+// NewCache so tests can exercise eviction without compiling DefaultCacheSize
+// expressions.
+func newCache(size int) *cache {
+	return &cache{lru: lru.New(size)}
 }

--- a/pkg/internal/approver/validation/cache_test.go
+++ b/pkg/internal/approver/validation/cache_test.go
@@ -54,3 +54,55 @@ func Test_Cache_Get(t *testing.T) {
 		})
 	}
 }
+
+// Test_Cache_Get_Evicts verifies that the cache is bounded: once more than
+// `size` distinct expressions have been compiled, the least-recently-used entry
+// is evicted, so a later Get for it compiles a fresh validator. This is the
+// mechanism that bounds memory under adversarial input (CWE-770).
+func Test_Cache_Get_Evicts(t *testing.T) {
+	c := newCache(2)
+
+	a1, err := c.Get("self == 'a'")
+	assert.NoError(t, err)
+	_, err = c.Get("self == 'b'")
+	assert.NoError(t, err)
+
+	// Compiling a third expression overflows the size-2 cache and evicts the
+	// least-recently-used entry, "self == 'a'".
+	_, err = c.Get("self == 'c'")
+	assert.NoError(t, err)
+
+	a2, err := c.Get("self == 'a'")
+	assert.NoError(t, err)
+	assert.NotSame(t, a1, a2, "evicted expression must be recompiled, not served from cache")
+}
+
+// Test_Cache_Get_KeepsRecentlyUsed verifies the eviction order is by recency:
+// touching an entry via Get protects it from eviction, while a colder entry is
+// evicted instead.
+func Test_Cache_Get_KeepsRecentlyUsed(t *testing.T) {
+	c := newCache(2)
+
+	a1, err := c.Get("self == 'a'")
+	assert.NoError(t, err)
+	b1, err := c.Get("self == 'b'")
+	assert.NoError(t, err)
+
+	// Touch "self == 'a'" so it becomes the most-recently-used; "self == 'b'"
+	// is now the eviction candidate.
+	a2, err := c.Get("self == 'a'")
+	assert.NoError(t, err)
+	assert.Same(t, a1, a2, "recently-used entry must remain cached")
+
+	// Overflow the cache: "self == 'b'" should be evicted, "self == 'a'" kept.
+	_, err = c.Get("self == 'c'")
+	assert.NoError(t, err)
+
+	a3, err := c.Get("self == 'a'")
+	assert.NoError(t, err)
+	assert.Same(t, a1, a3, "most-recently-used entry must survive eviction")
+
+	b2, err := c.Get("self == 'b'")
+	assert.NoError(t, err)
+	assert.NotSame(t, b1, b2, "least-recently-used entry must be evicted")
+}


### PR DESCRIPTION
## Summary

Bound the compiled CEL validator cache by replacing the unbounded global
`sync.Map` with a fixed-size LRU (`k8s.io/utils/lru`, already a dependency),
holding at most `DefaultCacheSize` (1024) compiled programs and evicting the
least-recently-used entry when full.

This is an **alternative to #924**, which solves the same problem by tying cache
entries to the CertificateRequestPolicy lifecycle. Both close the
memory-exhaustion variant of the linked issue; this PR does so with a smaller,
self-contained change. See the comparison below.

## Motivation

The CEL validator cache used a global `sync.Map` keyed by expression string with
no eviction — every unique expression compiled during the controller's lifetime
remained in memory permanently. This is the memory-exhaustion variant of
VC-53793 (CWE-770): a principal able to author `CertificateRequestPolicy`
resources — including via `--dry-run=server` CREATEs that are never persisted —
can grow controller memory without bound by submitting unique large expressions.

The CPU/goroutine-hang variant of the same issue was addressed separately by the
CEL cost limit in #923 (already merged, and the base of this branch).

## Design

A bounded cache is preferred here over lifecycle-keyed eviction because it keeps
the cache a self-contained concern:

- No knowledge of policy create/update/delete, and no controller or webhook
  plumbing — `Cache.Get(expr)` is unchanged.
- No per-replica eviction coordination; an entry for a deleted or rewritten
  policy simply ages out.
- A hard memory bound regardless of input.

Trade-off: under a flood of unique expressions, a legitimate policy's compiled
program may be evicted and recompiled on next use. This cost is bounded and is
already capped per compilation by the CEL cost limit from #923.

### Comparison with #924

| Aspect | This PR (LRU) | #924 (per-CRP lifecycle) |
|---|---|---|
| Production code touched | `cache.go` only | `cache.go`, `evaluator.go`, `allowed/validation.go`, `reconciler.go`, controller |
| Cache API | `Get(expr)` unchanged | `Get(policyName, expr)`, `Compile(expr)`, `Remove(policyName)` |
| Memory bound | hard cap (1024 entries) | live policies × expressions |
| New surface | none | `ValidatorCleaner` interface, controller delete-handling |
| Multi-replica eviction | n/a (size-bounded per replica) | best-effort, leader-only on delete |
| New dependency | none (`k8s.io/utils/lru` already present) | none |

Fixes: https://venafi.atlassian.net/browse/VC-53793

## Test plan

- [x] `Test_Cache_Get`: basic caching and error caching
- [x] `Test_Cache_Get_Evicts`: once the size limit is exceeded, the
  least-recently-used entry is evicted and recompiled on next Get
- [x] `Test_Cache_Get_KeepsRecentlyUsed`: touching an entry protects it from
  eviction; the colder entry is evicted instead
- [x] `make verify-golangci-lint` passes (0 issues); `go build ./...` and unit
  tests pass locally; `go mod tidy` produces no go.mod/go.sum changes

*Generated with Claude (Opus 4.8)*
