### PR TITLE
test: assert registry is unmodified when Store() panics

### DIFF
--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -73,6 +73,8 @@ func TestRegistry_Store(t *testing.T) {
 				assert.PanicsWithValue(t, test.panicMessage, func() {
 					r.Store(test.approvers...)
 				})
+				assert.Equal(t, len(test.preStored), len(r.Approvers()),
+					"registry must not be modified when Store panics")
 				return
 			}
 


### PR DESCRIPTION
## Motivation

Follow-up to #875. Copilot suggested adding a post-panic assertion to confirm `Store()` does not partially mutate the registry when it detects a duplicate. I deferred it from #875 so that fix could merge for the upcoming release.

## What

Adds a single `assert.Equal` after `PanicsWithValue` confirming `len(r.Approvers()) == len(test.preStored)` when a panic is expected. The assertion covers both existing panic cases via the same table-driven loop:

- `storing approvers with duplicate names should panic` (cross-batch)
- `storing duplicate names in a single call should panic` (in-batch, added in #875)

## Why

The current implementation validates before appending, so the invariant holds today. The assertion documents that invariant and would fail loudly if a future refactor reordered mutation and validation.

## Testing

```
$ _bin/tools/go test -v -run TestRegistry_Store ./pkg/registry/...
=== RUN   TestRegistry_Store
=== RUN   TestRegistry_Store/storing_duplicate_names_in_a_single_call_should_panic
=== RUN   TestRegistry_Store/storing_a_single_approver_should_succeed
=== RUN   TestRegistry_Store/storing_multiple_approvers_should_succeed
=== RUN   TestRegistry_Store/storing_approvers_with_duplicate_names_should_panic
--- PASS: TestRegistry_Store (0.00s)
PASS
ok      github.com/cert-manager/approver-policy/pkg/registry    0.057s
```