### PR TITLE
Document additional pre- and post-release checks in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,23 +9,200 @@ However, if a vulnerability is discovered we will respond in accordance with our
 
 There is a semi-automated release process for this project. When you create a Git tag with a tag name that has a `v` prefix and push it to GitHub it will trigger the [release workflow].
 
+### Narrate the release in `#cert-manager-dev`
+
+Releases are narrated as a single thread in [`#cert-manager-dev`](https://kubernetes.slack.com/archives/CDEQJ0Q8M) on the Kubernetes Slack. Open the thread before you start the pre-release checks, so each step that follows can be posted as a reply.
+
+Start with a top-level message such as:
+
+```
+:thread: Releasing approver-policy v0.26.0 ...
+```
+
+As the release progresses, reply in the thread with:
+
+- the pre-release check summary (see below);
+- the tag URL after pushing;
+- the release-workflow run URL once it starts building;
+- the published release URL with `:tada:` once it is live.
+
+This gives the whole team a single, scannable record of what was done, by whom, and when, and lets non-PANW maintainers see what is happening with the steps they cannot perform themselves (see "Post-release: Verify the Helm Chart Reaches ArtifactHub" below).
+
+### Pre-release Checks
+
+1. **Check for known vulnerabilities** using `govulncheck` and `trivy`:
+    ```sh
+    # Check the govulncheck GitHub Action is green on main:
+    # https://github.com/cert-manager/approver-policy/actions/workflows/govulncheck.yaml
+
+    # Run trivy locally (ArtifactHub uses trivy and flags MEDIUM+ vulnerabilities):
+    make _bin/tools/trivy
+    _bin/tools/trivy fs --scanners vuln .
+    ```
+    If trivy reports vulnerabilities, bump the affected dependencies before tagging,
+    even if they are indirect. ArtifactHub displays trivy results on the
+    [security report page](https://artifacthub.io/packages/helm/cert-manager/cert-manager-approver-policy?modal=security-report),
+    and users rely on a clean report.
+
+2. **Verify signed-tag config** so the release tag is shown as Verified on GitHub:
+    ```sh
+    git config --get tag.gpgsign     # must print: true
+    git config --get gpg.format      # ssh (or openpgp), matching your signing setup
+    git config --get user.signingkey # path to a key that is also registered with GitHub
+    ```
+    If `tag.gpgsign` is unset, `git tag --annotate` produces an unsigned tag and the
+    GitHub release page will display **Unverified** next to the tag. Set it globally
+    once with `git config --global tag.gpgsign true` so every future annotated tag
+    is signed automatically. (csi-driver-spiffe v0.14.0 was tagged unsigned for this
+    exact reason.)
+
+3. **Post a pre-release check summary to the Slack thread** so the team can see the
+   state of the world before you tag. Cover: govulncheck/trivy results, any
+   outstanding CVEs and how they have been addressed, sidecar image status (none
+   for approver-policy), notable community PRs included, dependency updates, and
+   anything else relevant to this release.
+
+### Doing a Release
+
 The release process for this repo is documented below:
 
 1. Create a tag for the new release:
     ```sh
-   export VERSION=v0.5.0-alpha.0
-   git tag --annotate --message="Release ${VERSION}" "${VERSION}"
-   git push origin "${VERSION}"
-   ```
+    export VERSION=v0.5.0-alpha.0
+    git tag --annotate --message="Release ${VERSION}" "${VERSION}"
+    git push origin "${VERSION}"
+    ```
+   Post the tag URL to the Slack thread.
+
 2. A GitHub action will see the new tag and do the following:
     - Build and publish any container images
     - Build and publish the OCI Helm chart
     - Create a draft GitHub release
+
+   Post the workflow-run URL to the Slack thread so others can follow along.
+
 3. Visit the [releases page], edit the draft release, click "Generate release notes", then edit the notes to add the following to the top
     ```
     approver-policy provides a policy engine for certificates issued by cert-manager!
     ```
-4. Publish the release.
+4. Publish the release. Post the release URL to the Slack thread, prefixed with `:tada:`.
+
+### Post-release: Verify the Helm Chart Reaches ArtifactHub
+
+> [!IMPORTANT]
+> The steps in this section can **only be performed by Palo Alto Networks
+> employees**. The [jetstack/jetstack-charts](https://github.com/jetstack/jetstack-charts)
+> repository is private and pre-dates the cert-manager project moving to a
+> community governance model — it remains the path through which OCI charts on
+> `quay.io/jetstack` are syndicated to `charts.jetstack.io` and ArtifactHub.
+>
+> If you are a release manager outside Palo Alto Networks, **do not skip this
+> section**. Post in the release Slack thread asking a PANW cert-manager
+> maintainer to run these steps, and link them this section as a reference.
+
+The release workflow pushes the Helm chart to `quay.io/jetstack`, and an
+`oci-sync` workflow in `jetstack/jetstack-charts` opens a PR to sync it to
+`charts.jetstack.io`. That PR requires a maintainer approval before it is merged.
+Until it is merged, ArtifactHub will continue to show the previous version.
+
+`oci-sync` runs hourly on cron. If you do not want to wait for the next scheduled
+run, trigger it on demand:
+
+```sh
+gh workflow run oci-sync.yaml --repo jetstack/jetstack-charts
+gh pr list --repo jetstack/jetstack-charts --search "oci-sync" --state open
+```
+
+**Before merging the sync PR**, verify that the chart published to the preview
+repo matches expectations. The Cloudflare Pages check on the sync PR posts a
+deployment preview URL — render the chart for both the new and previous releases
+from that preview, and diff them with version-label noise filtered out:
+
+```sh
+# PREVIEW is the per-deployment URL from the PR's Cloudflare Pages comment, e.g.
+# https://8cebb8e5.jetstack-charts.pages.dev
+export PREVIEW=https://DEPLOYMENT-ID.jetstack-charts.pages.dev
+export NEW=v0.26.0
+export OLD=v0.25.1     # the previous release
+
+helm template ap cert-manager-approver-policy --repo "$PREVIEW" --version "$NEW" > /tmp/ap-new.yaml
+helm template ap cert-manager-approver-policy --repo "$PREVIEW" --version "$OLD" > /tmp/ap-old.yaml
+
+diff -u /tmp/ap-old.yaml /tmp/ap-new.yaml \
+  | grep -v -E "^[-+][[:space:]]*(helm\.sh/chart:|app\.kubernetes\.io/version:|image:).*(${OLD}|${NEW})"
+```
+
+The only remaining diff should correspond to actual behavioural changes shipped
+in this release. Then confirm the referenced container image is published with
+the expected platforms:
+
+```sh
+make _bin/tools/crane
+_bin/tools/crane manifest "quay.io/jetstack/cert-manager-approver-policy:${NEW}"
+```
+
+Record the commands you ran (and any non-trivial filtered diff) as a comment on
+the sync PR before approving and merging — this leaves an audit trail for the
+next maintainer. Then approve and merge the sync PR.
+
+After merge, confirm the new version appears on ArtifactHub:
+https://artifacthub.io/packages/helm/cert-manager/cert-manager-approver-policy
+
+### Post-release: Check the ArtifactHub Security Report
+
+Once the new version appears on ArtifactHub, check its security report for
+vulnerabilities. approver-policy ships only the controller image — there are no
+sidecar images — so any finding here is in code or dependencies we control and
+should be addressed in a follow-up patch release.
+
+The security report is visible in the web UI at:
+
+https://artifacthub.io/packages/helm/cert-manager/cert-manager-approver-policy/VERSION?modal=security-report
+
+It can also be fetched programmatically using the [ArtifactHub API]. The package
+ID for approver-policy is `789b1172-cf45-4599-8553-06248bd5a441`. Note that
+ArtifactHub identifies chart versions without the `v` prefix — even though our
+release tags and the `version`/`appVersion` fields in `Chart.yaml` carry one —
+so the API path uses the bare semver (e.g. `0.26.0`, not `v0.26.0`, which 404s):
+
+```sh
+export VERSION=0.26.0
+make _bin/tools/yq
+curl -sL "https://artifacthub.io/api/v1/packages/789b1172-cf45-4599-8553-06248bd5a441/${VERSION}/security-report" \
+  | _bin/tools/yq -p json -o tsv '
+    ["IMAGE", "SEVERITY", "CVE", "PACKAGE", "INSTALLED", "FIXED"],
+    (
+      to_entries[] |
+      .key as $image |
+      .value.Results[]? |
+      .Vulnerabilities[]? |
+      [$image, .Severity, .VulnerabilityID, .PkgName, .InstalledVersion, .FixedVersion // "n/a"]
+    ) | @tsv
+  ' | column -t -s$'\t'
+```
+
+### Post-release: Notify Community Contributors
+
+For every non-bot, non-maintainer PR included in the release, comment thanking
+the author, linking the release, and asking them to install and verify the
+change in their own environment. For every public issue closed by those PRs,
+comment on the issue too — invite the original reporter (and any other
+commenters) to confirm the fix.
+
+Use this template on the PR:
+
+```
+@<author> This change has been included in [vX.Y.Z](https://github.com/cert-manager/approver-policy/releases/tag/vX.Y.Z), which is now published.
+
+Installation instructions are at https://cert-manager.io/docs/policy/approval/approver-policy/installation/
+
+If you are able to install the new release and verify the fix in your environment, that would be much appreciated. Thank you for the contribution.
+```
+
+When commenting on a closed issue, tailor the second sentence to the specific
+failure the reporter described, rather than the generic "verify the fix"
+wording — e.g. "confirm that the controller no longer deadlocks against its own
+webhook during reconciliation".
 
 ## Artifacts
 
@@ -36,5 +213,6 @@ This repo will produce the following artifacts each release. For documentation o
   *  The chart is also published to the legacy HTTP Helm repository at `https://charts.jetstack.io` (maintained by Venafi).
      Publishing to the legacy repo depends on a PR to be merged in a closed Venafi repo, and might be delayed.
 
+[ArtifactHub API]: https://artifacthub.io/docs/api/
 [release workflow]: https://github.com/cert-manager/approver-policy/actions/workflows/release.yaml
 [releases page]: https://github.com/cert-manager/approver-policy/releases

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,9 +35,11 @@ This gives the whole team a single, scannable record of what was done, by whom, 
     # Check the govulncheck GitHub Action is green on main:
     # https://github.com/cert-manager/approver-policy/actions/workflows/govulncheck.yaml
 
-    # Run trivy locally, reporting only fixable HIGH and CRITICAL vulnerabilities:
+    # Run trivy locally, reporting fixable vulnerabilities of all severities.
+    # ArtifactHub's security report shows all severities, but only fixable
+    # vulnerabilities can be addressed by bumping dependencies:
     make _bin/tools/trivy
-    _bin/tools/trivy fs --scanners vuln --ignore-unfixed --severity HIGH,CRITICAL .
+    _bin/tools/trivy fs --scanners vuln --ignore-unfixed .
     ```
     If trivy reports vulnerabilities, bump the affected dependencies before tagging,
     even if they are indirect. ArtifactHub displays trivy results on the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,9 +35,9 @@ This gives the whole team a single, scannable record of what was done, by whom, 
     # Check the govulncheck GitHub Action is green on main:
     # https://github.com/cert-manager/approver-policy/actions/workflows/govulncheck.yaml
 
-    # Run trivy locally (ArtifactHub uses trivy and flags MEDIUM+ vulnerabilities):
+    # Run trivy locally, reporting only fixable HIGH and CRITICAL vulnerabilities:
     make _bin/tools/trivy
-    _bin/tools/trivy fs --scanners vuln .
+    _bin/tools/trivy fs --scanners vuln --ignore-unfixed --severity HIGH,CRITICAL .
     ```
     If trivy reports vulnerabilities, bump the affected dependencies before tagging,
     even if they are indirect. ArtifactHub displays trivy results on the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,8 +38,11 @@ This gives the whole team a single, scannable record of what was done, by whom, 
     # Build the manager image locally and scan it with trivy, reporting
     # fixable vulnerabilities of all severities. This matches what ArtifactHub
     # scans (the published image); only fixable vulnerabilities can be
-    # addressed by bumping dependencies:
-    make trivy-scan-manager
+    # addressed by bumping dependencies. vendor-go ensures the image is built
+    # with the same pinned Go version as the release workflow, so Go stdlib
+    # vulnerabilities already fixed by a toolchain bump are not falsely
+    # reported by an older host Go:
+    make vendor-go trivy-scan-manager
     ```
     If trivy reports vulnerabilities, bump the affected dependencies before tagging,
     even if they are indirect. ArtifactHub displays trivy results on the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,11 +35,11 @@ This gives the whole team a single, scannable record of what was done, by whom, 
     # Check the govulncheck GitHub Action is green on main:
     # https://github.com/cert-manager/approver-policy/actions/workflows/govulncheck.yaml
 
-    # Run trivy locally, reporting fixable vulnerabilities of all severities.
-    # ArtifactHub's security report shows all severities, but only fixable
-    # vulnerabilities can be addressed by bumping dependencies:
-    make _bin/tools/trivy
-    _bin/tools/trivy fs --scanners vuln --ignore-unfixed .
+    # Build the manager image locally and scan it with trivy, reporting
+    # fixable vulnerabilities of all severities. This matches what ArtifactHub
+    # scans (the published image); only fixable vulnerabilities can be
+    # addressed by bumping dependencies:
+    make trivy-scan-manager
     ```
     If trivy reports vulnerabilities, bump the affected dependencies before tagging,
     even if they are indirect. ArtifactHub displays trivy results on the

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -42,3 +42,11 @@ release:
 	@echo "RELEASE_HELM_CHART_VERSION=$(helm_chart_version)" >> "$(GITHUB_OUTPUT)"
 
 	@echo "Release complete!"
+
+.PHONY: trivy-scan-manager
+## Build the manager container image for the local architecture and scan it
+## for fixable vulnerabilities using trivy. This approximates the security
+## report that ArtifactHub generates for the published image.
+## @category Development
+trivy-scan-manager: docker-tarball-manager | $(NEEDS_TRIVY)
+	$(TRIVY) image --input $(docker_tarball_path_manager) --ignore-unfixed --exit-code 1


### PR DESCRIPTION
## Motivation

While releasing approver-policy [v0.26.0](https://github.com/cert-manager/approver-policy/releases/tag/v0.26.0) earlier today, I performed a number of checks that were not codified anywhere in `RELEASE.md`. Some mirror what landed in [cert-manager/csi-driver-spiffe#540](https://github.com/cert-manager/csi-driver-spiffe/pull/540) yesterday; others are new learnings from this release (signed-tag config, pre-merge verification of the `jetstack-charts` sync PR, community-author pings, narrating the release in Slack).

This PR records all of them so the next release manager does not have to rediscover the process.

## What changes

`RELEASE.md` only — no code, no Makefile, no CI changes. The tooling referenced (`trivy`, `crane`, `yq`) is already wired up in `make/_shared/tools/00_mod.mk`.

New sections:

- **Narrate the release in `#cert-manager-dev`** — open a thread on the Kubernetes Slack at the start of the release and post the pre-release summary, tag URL, build URL, and final `:tada:` announcement as replies.
- **Pre-release Checks** — run `govulncheck` (GitHub Action) and `trivy fs` locally; verify `tag.gpgsign=true` so the release tag shows as **Verified** on GitHub.
- **Post-release: Verify the Helm Chart Reaches ArtifactHub** — trigger the `oci-sync` workflow on demand instead of waiting for cron; render the chart from the Cloudflare Pages preview for the new and previous releases and `diff` them with version-label noise filtered out; check the multi-arch image with `crane manifest`; record the verification on the sync PR before approving and merging.
- **Post-release: Check the ArtifactHub Security Report** — web UI plus a `curl | yq` one-liner using approver-policy's ArtifactHub package id `789b1172-cf45-4599-8553-06248bd5a441`.
- **Post-release: Notify Community Contributors** — comment on every non-bot, non-maintainer PR included in the release and on the public issues those PRs close, using the canonical template (lifted from [cert-manager/csi-driver-spiffe#477](https://github.com/cert-manager/csi-driver-spiffe/pull/477#issuecomment-4732856279)).

The post-release `jetstack-charts` section also calls out, in an `[!IMPORTANT]` callout, that those steps can only be performed by Palo Alto Networks employees (the `jetstack-charts` repo pre-dates the cert-manager project's move to community governance). Non-PANW release managers should delegate by pinging in the release Slack thread.

## How this was tested

`RELEASE.md` is documentation, so the verification is:

- Walked through the new sections against today's v0.26.0 release end-to-end: every check we performed appears, in the right order, with reproducible commands.
- Validated every external link in the new content (govulncheck workflow, ArtifactHub package page, install docs, `#cert-manager-dev` Slack channel) resolves to HTTP 200.
- Rendered locally to confirm code fences, lists, and the `[!IMPORTANT]` callout format correctly.

## Out of scope

The new `tag.gpgsign`, sync-PR pre-merge verification, community-ping, and Slack-thread sections would also make sense in `csi-driver-spiffe/RELEASE.md` (which was updated yesterday in #540). I'll raise a follow-up PR there once this lands.