### PR TITLE
feat: add startupapicheck Job to verify webhook readiness

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,8 @@ jobs:
     outputs:
       RELEASE_OCI_MANAGER_IMAGE: ${{ steps.release.outputs.RELEASE_OCI_MANAGER_IMAGE }}
       RELEASE_OCI_MANAGER_TAG: ${{ steps.release.outputs.RELEASE_OCI_MANAGER_TAG }}
+      RELEASE_OCI_STARTUPAPICHECK_IMAGE: ${{ steps.release.outputs.RELEASE_OCI_STARTUPAPICHECK_IMAGE }}
+      RELEASE_OCI_STARTUPAPICHECK_TAG: ${{ steps.release.outputs.RELEASE_OCI_STARTUPAPICHECK_TAG }}
       RELEASE_HELM_CHART_IMAGE: ${{ steps.release.outputs.RELEASE_HELM_CHART_IMAGE }}
       RELEASE_HELM_CHART_VERSION: ${{ steps.release.outputs.RELEASE_HELM_CHART_VERSION }}
 
@@ -56,6 +58,8 @@ jobs:
           touch .notes-file
           echo "OCI_MANAGER_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_OCI_MANAGER_IMAGE }}" >> .notes-file
           echo "OCI_MANAGER_TAG: ${{ needs.build_and_push.outputs.RELEASE_OCI_MANAGER_TAG }}" >> .notes-file
+          echo "OCI_STARTUPAPICHECK_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_OCI_STARTUPAPICHECK_IMAGE }}" >> .notes-file
+          echo "OCI_STARTUPAPICHECK_TAG: ${{ needs.build_and_push.outputs.RELEASE_OCI_STARTUPAPICHECK_TAG }}" >> .notes-file
           echo "HELM_CHART_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_IMAGE }}" >> .notes-file
           echo "HELM_CHART_VERSION: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_VERSION }}" >> .notes-file
 

--- a/cmd/startupapicheck/main.go
+++ b/cmd/startupapicheck/main.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	policyapi "github.com/cert-manager/approver-policy/pkg/apis/policy/v1alpha1"
+)
+
+func main() {
+	ctx := context.Background()
+
+	cmd := &cobra.Command{
+		Use:           "startupapicheck",
+		Short:         "Check that approver-policy started successfully",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+
+	// Allow `-v` without a value (same UX as cert-manager startupapicheck / cmctl).
+	cmd.PersistentFlags().CountP("v", "v", "verbose logging; can be repeated")
+	cmd.PersistentFlags().Lookup("v").NoOptDefVal = "1"
+
+	cmd.AddCommand(newCmdCheck())
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func newCmdCheck() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Check approver-policy components",
+	}
+	cmd.AddCommand(newCmdCheckAPI())
+	return cmd
+}
+
+type checkAPIOptions struct {
+	wait     time.Duration
+	interval time.Duration
+	verbose  int
+}
+
+func newCmdCheckAPI() *cobra.Command {
+	o := &checkAPIOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "api",
+		Short: "Check if the approver-policy API is ready",
+		Long: `This check attempts to perform a dry-run create of a
+CertificateRequestPolicy resource in order to verify that CRDs are installed
+and the approver-policy validating webhook is reachable by the Kubernetes API server.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.verbose, _ = cmd.Root().PersistentFlags().GetCount("v")
+			return o.run(cmd.Context(), cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().DurationVar(&o.wait, "wait", 0, "Wait until the approver-policy API is ready (default 0s = poll once)")
+	cmd.Flags().DurationVar(&o.interval, "interval", 5*time.Second, "Time between checks when waiting, must include unit, e.g. 1m or 10s")
+
+	return cmd
+}
+
+func (o *checkAPIOptions) run(ctx context.Context, out io.Writer) error {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return fmt.Errorf("while getting kubeconfig: %w", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := policyapi.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("while configuring scheme: %w", err)
+	}
+
+	dryRun := true
+	cl, err := client.New(cfg, client.Options{
+		Scheme: scheme,
+		DryRun: &dryRun,
+	})
+	if err != nil {
+		return fmt.Errorf("while creating client: %w", err)
+	}
+
+	start := time.Now()
+	var lastError error
+	pollErr := wait.PollUntilContextCancel(ctx, o.interval, true, func(ctx context.Context) (bool, error) {
+		if err := checkAPI(ctx, cl); err != nil {
+			if o.verbose > 0 {
+				fmt.Fprintf(os.Stderr, "Not ready: %v\n", err)
+			}
+			lastError = err
+
+			if o.wait > 0 && time.Since(start) > o.wait {
+				return false, context.DeadlineExceeded
+			}
+			if o.wait == 0 {
+				return false, context.DeadlineExceeded
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if pollErr != nil {
+		if errors.Is(pollErr, context.DeadlineExceeded) && o.wait > 0 && o.verbose > 0 {
+			fmt.Fprintf(os.Stderr, "Timed out after %s: %v\n", o.wait, lastError)
+		}
+		if lastError != nil {
+			return lastError
+		}
+		return pollErr
+	}
+
+	fmt.Fprintln(out, "The approver-policy API is ready")
+	return nil
+}
+
+func checkAPI(ctx context.Context, cl client.Client) error {
+	crp := &policyapi.CertificateRequestPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "startupapicheck-",
+		},
+		Spec: policyapi.CertificateRequestPolicySpec{
+			Selector: policyapi.CertificateRequestPolicySelector{
+				IssuerRef: &policyapi.CertificateRequestPolicySelectorIssuerRef{},
+			},
+		},
+	}
+	return cl.Create(ctx, crp)
+}

--- a/deploy/charts/approver-policy/README.md
+++ b/deploy/charts/approver-policy/README.md
@@ -519,5 +519,187 @@ For more information, see [Configure a Security Context for a Pod or Container](
 
 Container Security Context to be set on the controller component container. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
+#### **startupapicheck.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Enables the startup API check Job that verifies the webhook is ready.
+#### **startupapicheck.securityContext** ~ `object`
+> Default value:
+> ```yaml
+> runAsNonRoot: true
+> seccompProfile:
+>   type: RuntimeDefault
+> ```
+
+Pod Security Context to be set on the startupapicheck component Pod. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+
+#### **startupapicheck.containerSecurityContext** ~ `object`
+> Default value:
+> ```yaml
+> allowPrivilegeEscalation: false
+> capabilities:
+>   drop:
+>     - ALL
+> readOnlyRootFilesystem: true
+> ```
+
+Container Security Context to be set on the startupapicheck container. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+
+#### **startupapicheck.timeout** ~ `string`
+> Default value:
+> ```yaml
+> 1m
+> ```
+
+Timeout for the startupapicheck 'check api' command.
+#### **startupapicheck.backoffLimit** ~ `number`
+> Default value:
+> ```yaml
+> 4
+> ```
+
+Job backoffLimit
+#### **startupapicheck.ttlSecondsAfterFinished** ~ `integer`
+
+Limits the lifetime of a Job that has finished execution (either Complete or Failed). Disabled by default (field is not set).
+
+
+#### **startupapicheck.jobAnnotations** ~ `object`
+> Default value:
+> ```yaml
+> helm.sh/hook: post-install,post-upgrade
+> helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+> helm.sh/hook-weight: "1"
+> ```
+
+Optional additional annotations to add to the startupapicheck Job.
+
+#### **startupapicheck.podAnnotations** ~ `object`
+
+Optional additional annotations to add to the startupapicheck Pods.
+
+#### **startupapicheck.extraArgs** ~ `array`
+> Default value:
+> ```yaml
+> - -v
+> ```
+
+Additional command line flags to pass to startupapicheck binary. Verbose logging is enabled by default so that if startupapicheck fails, you can know what exactly caused the failure.
+
+#### **startupapicheck.resources** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Resources to provide to the startupapicheck pod.
+#### **startupapicheck.nodeSelector** ~ `object`
+> Default value:
+> ```yaml
+> kubernetes.io/os: linux
+> ```
+
+The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels.
+
+#### **startupapicheck.affinity** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+A Kubernetes Affinity, if required.
+#### **startupapicheck.tolerations** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+A list of Kubernetes Tolerations, if required.
+#### **startupapicheck.podLabels** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Optional additional labels to add to the startupapicheck Pods.
+#### **startupapicheck.image.registry** ~ `string`
+
+Deprecated: per-component registry prefix.  
+Prefer using the global `imageRegistry`/`imageNamespace` values.
+
+#### **startupapicheck.image.name** ~ `string`
+> Default value:
+> ```yaml
+> cert-manager-approver-policy-startupapicheck
+> ```
+
+The image name for the approver-policy startupapicheck.
+
+#### **startupapicheck.image.repository** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `startupapicheck.image.name`).
+
+#### **startupapicheck.image.tag** ~ `string`
+
+Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.
+
+#### **startupapicheck.image.digest** ~ `string`
+
+Setting a digest pins the image.
+
+#### **startupapicheck.image.pullPolicy** ~ `string`
+> Default value:
+> ```yaml
+> IfNotPresent
+> ```
+
+Kubernetes imagePullPolicy on the Job.
+#### **startupapicheck.rbac.annotations** ~ `object`
+> Default value:
+> ```yaml
+> helm.sh/hook: post-install,post-upgrade
+> helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+> helm.sh/hook-weight: "-5"
+> ```
+
+Annotations for the startup API Check Job RBAC resources.
+
+#### **startupapicheck.serviceAccount.create** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Specifies whether a service account should be created.
+#### **startupapicheck.serviceAccount.name** ~ `string`
+
+The name of the service account to use.  
+If not set and create is true, a name is generated using the fullname template.
+
+#### **startupapicheck.serviceAccount.annotations** ~ `object`
+> Default value:
+> ```yaml
+> helm.sh/hook: post-install,post-upgrade
+> helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+> helm.sh/hook-weight: "-5"
+> ```
+
+Optional additional annotations to add to the Job's Service Account.
+
+#### **startupapicheck.serviceAccount.automountServiceAccountToken** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Automount API credentials for a Service Account.
+
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/approver-policy/templates/NOTES.txt
+++ b/deploy/charts/approver-policy/templates/NOTES.txt
@@ -34,6 +34,27 @@ CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}
 
+{{ .Chart.Name }} has been deployed successfully!
+
+{{- if .Values.startupapicheck.enabled }}
+
+A startupapicheck Job has been created to verify that the webhook is ready.
+
+To wait for the webhook to be ready before the installation completes, use:
+  helm install {{ .Release.Name }} --wait --wait-for-jobs
+
+Note: Both --wait and --wait-for-jobs flags are required to wait for Jobs to complete.
+Helm also waits for post-install hook Jobs (including startupapicheck) during install.
+
+To check if the webhook is ready:
+  kubectl get job -n {{ .Release.Namespace }} {{ include "startupapicheck.fullname" . }}
+
+{{- else }}
+
+Note: The startupapicheck Job is disabled. The webhook may not be immediately ready after installation.
+
+{{- end }}
+
 {{ .Chart.Name }} is a cert-manager project.
 
 If you're a new user, we recommend that you read the [cert-manager Approval Policy documentation] to learn more.

--- a/deploy/charts/approver-policy/templates/_helpers.tpl
+++ b/deploy/charts/approver-policy/templates/_helpers.tpl
@@ -111,3 +111,23 @@ minAvailable: {{ default 1 .minAvailable }}
 maxUnavailable: {{ .maxUnavailable }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+startupapicheck helpers
+*/}}
+{{- define "startupapicheck.name" -}}
+{{- printf "startupapicheck" -}}
+{{- end -}}
+
+{{- define "startupapicheck.fullname" -}}
+{{- $trimmedName := printf "%s" (include "cert-manager-approver-policy.name" .) | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s-startupapicheck" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "startupapicheck.serviceAccountName" -}}
+{{- if .Values.startupapicheck.serviceAccount.create -}}
+    {{ default (include "startupapicheck.fullname" .) .Values.startupapicheck.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.startupapicheck.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/approver-policy/templates/startupapicheck-job.yaml
+++ b/deploy/charts/approver-policy/templates/startupapicheck-job.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.startupapicheck.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "startupapicheck.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    {{- include "cert-manager-approver-policy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: startupapicheck
+  {{- with .Values.startupapicheck.jobAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.startupapicheck.backoffLimit }}
+  {{- if hasKey .Values.startupapicheck "ttlSecondsAfterFinished" }}
+  ttlSecondsAfterFinished: {{ .Values.startupapicheck.ttlSecondsAfterFinished }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "startupapicheck.name" . }}
+        {{- include "cert-manager-approver-policy.labels" . | nindent 8 }}
+        app.kubernetes.io/component: startupapicheck
+        {{- with .Values.startupapicheck.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.startupapicheck.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "startupapicheck.serviceAccountName" . }}
+      {{- with .Values.startupapicheck.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}-startupapicheck
+          image: "{{ template "approver-policy.image" (tuple .Values.startupapicheck.image .Values.imageRegistry .Values.imageNamespace .Values.startupapicheck.image._defaultReference) }}"
+          imagePullPolicy: {{ .Values.startupapicheck.image.pullPolicy }}
+          args:
+            - check
+            - api
+            - --wait={{ .Values.startupapicheck.timeout }}
+            {{- with .Values.startupapicheck.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.startupapicheck.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupapicheck.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.startupapicheck.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.startupapicheck.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.startupapicheck.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/approver-policy/templates/startupapicheck-rbac.yaml
+++ b/deploy/charts/approver-policy/templates/startupapicheck-rbac.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.startupapicheck.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "startupapicheck.fullname" . }}:create-crp
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    {{- include "cert-manager-approver-policy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: startupapicheck
+  {{- with .Values.startupapicheck.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: ["policy.cert-manager.io"]
+    resources: ["certificaterequestpolicies"]
+    verbs: ["create", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "startupapicheck.fullname" . }}:create-crp
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    {{- include "cert-manager-approver-policy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: startupapicheck
+  {{- with .Values.startupapicheck.rbac.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "startupapicheck.fullname" . }}:create-crp
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "startupapicheck.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/charts/approver-policy/templates/startupapicheck-serviceaccount.yaml
+++ b/deploy/charts/approver-policy/templates/startupapicheck-serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.startupapicheck.enabled }}
+{{- if .Values.startupapicheck.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.startupapicheck.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ include "startupapicheck.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- with .Values.startupapicheck.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    {{- include "cert-manager-approver-policy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: startupapicheck
+{{- end }}
+{{- end }}

--- a/deploy/charts/approver-policy/values.schema.json
+++ b/deploy/charts/approver-policy/values.schema.json
@@ -72,6 +72,9 @@
         "securityContext": {
           "$ref": "#/$defs/helm-values.securityContext"
         },
+        "startupapicheck": {
+          "$ref": "#/$defs/helm-values.startupapicheck"
+        },
         "strategy": {
           "$ref": "#/$defs/helm-values.strategy"
         },
@@ -543,6 +546,271 @@
       },
       "description": "Pod Security Context.\nFor more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).",
       "type": "object"
+    },
+    "helm-values.startupapicheck": {
+      "additionalProperties": false,
+      "properties": {
+        "affinity": {
+          "$ref": "#/$defs/helm-values.startupapicheck.affinity"
+        },
+        "backoffLimit": {
+          "$ref": "#/$defs/helm-values.startupapicheck.backoffLimit"
+        },
+        "containerSecurityContext": {
+          "$ref": "#/$defs/helm-values.startupapicheck.containerSecurityContext"
+        },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.startupapicheck.enabled"
+        },
+        "extraArgs": {
+          "$ref": "#/$defs/helm-values.startupapicheck.extraArgs"
+        },
+        "image": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image"
+        },
+        "jobAnnotations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.jobAnnotations"
+        },
+        "nodeSelector": {
+          "$ref": "#/$defs/helm-values.startupapicheck.nodeSelector"
+        },
+        "podAnnotations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.podAnnotations"
+        },
+        "podLabels": {
+          "$ref": "#/$defs/helm-values.startupapicheck.podLabels"
+        },
+        "rbac": {
+          "$ref": "#/$defs/helm-values.startupapicheck.rbac"
+        },
+        "resources": {
+          "$ref": "#/$defs/helm-values.startupapicheck.resources"
+        },
+        "securityContext": {
+          "$ref": "#/$defs/helm-values.startupapicheck.securityContext"
+        },
+        "serviceAccount": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount"
+        },
+        "timeout": {
+          "$ref": "#/$defs/helm-values.startupapicheck.timeout"
+        },
+        "tolerations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.tolerations"
+        },
+        "ttlSecondsAfterFinished": {
+          "$ref": "#/$defs/helm-values.startupapicheck.ttlSecondsAfterFinished"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.affinity": {
+      "default": {},
+      "description": "A Kubernetes Affinity, if required.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.backoffLimit": {
+      "default": 4,
+      "description": "Job backoffLimit",
+      "type": "number"
+    },
+    "helm-values.startupapicheck.containerSecurityContext": {
+      "default": {
+        "allowPrivilegeEscalation": false,
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        },
+        "readOnlyRootFilesystem": true
+      },
+      "description": "Container Security Context to be set on the startupapicheck container. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.enabled": {
+      "default": true,
+      "description": "Enables the startup API check Job that verifies the webhook is ready.",
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.extraArgs": {
+      "default": [
+        "-v"
+      ],
+      "description": "Additional command line flags to pass to startupapicheck binary. Verbose logging is enabled by default so that if startupapicheck fails, you can know what exactly caused the failure.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.startupapicheck.image": {
+      "additionalProperties": false,
+      "properties": {
+        "_defaultReference": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image._defaultReference"
+        },
+        "digest": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.digest"
+        },
+        "name": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.name"
+        },
+        "pullPolicy": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.pullPolicy"
+        },
+        "registry": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.registry"
+        },
+        "repository": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.repository"
+        },
+        "tag": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.tag"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.image._defaultReference": {
+      "default": ":v0.0.0",
+      "description": "WARNING: For internal use only; overwritten before releasing the chart.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.image.digest": {
+      "description": "Setting a digest pins the image.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.image.name": {
+      "default": "cert-manager-approver-policy-startupapicheck",
+      "description": "The image name for the approver-policy startupapicheck.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.image.pullPolicy": {
+      "default": "IfNotPresent",
+      "description": "Kubernetes imagePullPolicy on the Job.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.image.registry": {
+      "description": "Deprecated: per-component registry prefix.\nPrefer using the global `imageRegistry`/`imageNamespace` values.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.image.repository": {
+      "default": "",
+      "description": "Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `startupapicheck.image.name`).",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.image.tag": {
+      "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.jobAnnotations": {
+      "default": {
+        "helm.sh/hook": "post-install,post-upgrade",
+        "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+        "helm.sh/hook-weight": "1"
+      },
+      "description": "Optional additional annotations to add to the startupapicheck Job.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.nodeSelector": {
+      "default": {
+        "kubernetes.io/os": "linux"
+      },
+      "description": "The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with matching labels.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.podAnnotations": {
+      "description": "Optional additional annotations to add to the startupapicheck Pods.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.podLabels": {
+      "default": {},
+      "description": "Optional additional labels to add to the startupapicheck Pods.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.rbac": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.rbac.annotations"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.rbac.annotations": {
+      "default": {
+        "helm.sh/hook": "post-install,post-upgrade",
+        "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+        "helm.sh/hook-weight": "-5"
+      },
+      "description": "Annotations for the startup API Check Job RBAC resources.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.resources": {
+      "default": {},
+      "description": "Resources to provide to the startupapicheck pod.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.securityContext": {
+      "default": {
+        "runAsNonRoot": true,
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+        }
+      },
+      "description": "Pod Security Context to be set on the startupapicheck component Pod. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.serviceAccount": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount.annotations"
+        },
+        "automountServiceAccountToken": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount.automountServiceAccountToken"
+        },
+        "create": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount.create"
+        },
+        "name": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount.name"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.serviceAccount.annotations": {
+      "default": {
+        "helm.sh/hook": "post-install,post-upgrade",
+        "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded",
+        "helm.sh/hook-weight": "-5"
+      },
+      "description": "Optional additional annotations to add to the Job's Service Account.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.serviceAccount.automountServiceAccountToken": {
+      "default": true,
+      "description": "Automount API credentials for a Service Account.",
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.serviceAccount.create": {
+      "default": true,
+      "description": "Specifies whether a service account should be created.",
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.serviceAccount.name": {
+      "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.timeout": {
+      "default": "1m",
+      "description": "Timeout for the startupapicheck 'check api' command.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.tolerations": {
+      "default": [],
+      "description": "A list of Kubernetes Tolerations, if required.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.startupapicheck.ttlSecondsAfterFinished": {
+      "description": "Limits the lifetime of a Job that has finished execution (either Complete or Failed). Disabled by default (field is not set)."
     },
     "helm-values.strategy": {
       "default": {},

--- a/deploy/charts/approver-policy/values.yaml
+++ b/deploy/charts/approver-policy/values.yaml
@@ -344,3 +344,131 @@ containerSecurityContext:
     drop:
     - ALL
   readOnlyRootFilesystem: true
+
+startupapicheck:
+  # Enables the startup API check Job that verifies the webhook is ready.
+  enabled: true
+
+  # Pod Security Context to be set on the startupapicheck component Pod.
+  # For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+  # +docs:property
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
+  # Container Security Context to be set on the startupapicheck container.
+  # For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+  # +docs:property
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+
+  # Timeout for the startupapicheck 'check api' command.
+  timeout: 1m
+
+  # Job backoffLimit
+  backoffLimit: 4
+
+  # Limits the lifetime of a Job that has finished execution (either Complete
+  # or Failed). Disabled by default (field is not set).
+  # +docs:property
+  # +docs:type=integer
+  # ttlSecondsAfterFinished:
+
+  # Optional additional annotations to add to the startupapicheck Job.
+  # +docs:property
+  jobAnnotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+
+  # Optional additional annotations to add to the startupapicheck Pods.
+  # +docs:property
+  # podAnnotations: {}
+
+  # Additional command line flags to pass to startupapicheck binary.
+  # Verbose logging is enabled by default so that if startupapicheck fails, you
+  # can know what exactly caused the failure.
+  # +docs:property
+  extraArgs:
+    - -v
+
+  # Resources to provide to the startupapicheck pod.
+  resources: {}
+
+  # The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with
+  # matching labels.
+  # +docs:property
+  nodeSelector:
+    kubernetes.io/os: linux
+
+  # A Kubernetes Affinity, if required.
+  affinity: {}
+
+  # A list of Kubernetes Tolerations, if required.
+  tolerations: []
+
+  # Optional additional labels to add to the startupapicheck Pods.
+  podLabels: {}
+
+  image:
+    # Deprecated: per-component registry prefix.
+    # Prefer using the global `imageRegistry`/`imageNamespace` values.
+    # +docs:property
+    # registry: ""
+
+    # The image name for the approver-policy startupapicheck.
+    # +docs:property
+    name: cert-manager-approver-policy-startupapicheck
+
+    # Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `startupapicheck.image.name`).
+    # +docs:property
+    repository: ""
+
+    # Override the image tag to deploy by setting this variable.
+    # If no value is set, the chart's appVersion is used.
+    # +docs:property
+    # tag: vX.Y.Z
+
+    # Setting a digest pins the image.
+    # +docs:property
+    # digest: sha256:...
+
+    # Kubernetes imagePullPolicy on the Job.
+    pullPolicy: IfNotPresent
+
+    # WARNING: For internal use only; overwritten before releasing the chart.
+    # +docs:hidden
+    _defaultReference: :v0.0.0
+
+  rbac:
+    # Annotations for the startup API Check Job RBAC resources.
+    # +docs:property
+    annotations:
+      helm.sh/hook: post-install,post-upgrade
+      helm.sh/hook-weight: "-5"
+      helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+
+  serviceAccount:
+    # Specifies whether a service account should be created.
+    create: true
+
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template.
+    # +docs:property
+    # name: ""
+
+    # Optional additional annotations to add to the Job's Service Account.
+    # +docs:property
+    annotations:
+      helm.sh/hook: post-install,post-upgrade
+      helm.sh/hook-weight: "-5"
+      helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+
+    # Automount API credentials for a Service Account.
+    # +docs:property
+    automountServiceAccountToken: true

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -17,7 +17,7 @@ repo_name := github.com/cert-manager/approver-policy
 kind_cluster_name := approver-policy
 kind_cluster_config := $(bin_dir)/scratch/kind_cluster.yaml
 
-build_names := manager
+build_names := manager startupapicheck
 
 go_manager_main_dir := ./cmd
 go_manager_mod_dir := .
@@ -26,6 +26,14 @@ oci_manager_base_image_flavor := static
 oci_manager_image_name := quay.io/jetstack/cert-manager-approver-policy
 oci_manager_image_tag := $(VERSION)
 oci_manager_image_name_development := cert-manager.local/cert-manager-approver-policy
+
+go_startupapicheck_main_dir := ./cmd/startupapicheck
+go_startupapicheck_mod_dir := .
+go_startupapicheck_ldflags := -X $(repo_name)/pkg/internal/version.AppVersion=$(VERSION) -X $(repo_name)/pkg/internal/version.GitCommit=$(GITCOMMIT)
+oci_startupapicheck_base_image_flavor := static
+oci_startupapicheck_image_name := quay.io/jetstack/cert-manager-approver-policy-startupapicheck
+oci_startupapicheck_image_tag := $(VERSION)
+oci_startupapicheck_image_name_development := cert-manager.local/cert-manager-approver-policy-startupapicheck
 
 deploy_name := approver-policy
 deploy_namespace := cert-manager
@@ -39,6 +47,7 @@ golangci_lint_config := .golangci.yaml
 
 define helm_values_mutation_function
 $(YQ) \
-	'( .image._defaultReference = ":$(oci_manager_image_tag)" )' \
+	'( .image._defaultReference = ":$(oci_manager_image_tag)" ) | \
+	( .startupapicheck.image._defaultReference = ":$(oci_startupapicheck_image_tag)" )' \
 	$1 --inplace
 endef

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -34,10 +34,13 @@ include make/test-unit.mk
 ## @category [shared] Release
 release:
 	$(MAKE) oci-push-manager
+	$(MAKE) oci-push-startupapicheck
 	$(MAKE) helm-chart-oci-push
 
 	@echo "RELEASE_OCI_MANAGER_IMAGE=$(oci_manager_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_MANAGER_TAG=$(oci_manager_image_tag)" >> "$(GITHUB_OUTPUT)"
+	@echo "RELEASE_OCI_STARTUPAPICHECK_IMAGE=$(oci_startupapicheck_image_name)" >> "$(GITHUB_OUTPUT)"
+	@echo "RELEASE_OCI_STARTUPAPICHECK_TAG=$(oci_startupapicheck_image_tag)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_HELM_CHART_IMAGE=$(helm_chart_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_HELM_CHART_VERSION=$(helm_chart_version)" >> "$(GITHUB_OUTPUT)"
 

--- a/make/test-smoke.mk
+++ b/make/test-smoke.mk
@@ -42,11 +42,13 @@ smoke-setup-cert-manager: | kind-cluster $(NEEDS_HELM) $(NEEDS_KUBECTL)
 # When a "test-smoke" target is run, the currently active cluster must be the kind
 # cluster created by the "kind-cluster" target.
 ifeq ($(findstring test-smoke,$(MAKECMDGOALS)),test-smoke)
-install: kind-cluster oci-load-manager
+install: kind-cluster oci-load-manager oci-load-startupapicheck
 endif
 
 test-smoke-deps: INSTALL_OPTIONS :=
 test-smoke-deps: INSTALL_OPTIONS += --set image.repository=$(oci_manager_image_name_development)
+test-smoke-deps: INSTALL_OPTIONS += --set startupapicheck.image.repository=$(oci_startupapicheck_image_name_development)
+test-smoke-deps: INSTALL_OPTIONS += --wait-for-jobs
 test-smoke-deps: smoke-setup-cert-manager
 test-smoke-deps: install
 


### PR DESCRIPTION
## Summary
- Add a `startupapicheck` Helm Job (post-install/post-upgrade) that dry-run creates a `CertificateRequestPolicy`
- Wire a second OCI image (`cert-manager-approver-policy-startupapicheck`) and chart values/RBAC/NOTES
- Enables `helm install --wait --wait-for-jobs` to wait until the validating webhook is ready

Fixes #782

## Test plan
- [x] `go build ./cmd/startupapicheck/...`
- [x] `make verify-helm-values`
- [x] `helm template` with `startupapicheck.enabled=false` omits Job resources
- [ ] `make test-smoke` (loads both images; needs kind)
- [ ] Fresh install with `--wait --wait-for-jobs` waits for Job success