### PR TITLE
Adopt the shared kube-api-linter makefile module

### DIFF
--- a/.golangci.kube-api-linter.yaml
+++ b/.golangci.kube-api-linter.yaml
@@ -14,3 +14,7 @@ linters:
       - linters:
           - kubeapilinter
         path-except: pkg/apis/.*
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.kube-api-linter.yaml
+++ b/.golangci.kube-api-linter.yaml
@@ -8,7 +8,7 @@ linters:
     custom:
       kubeapilinter:
         type: module
-        description: Kube API Linter lints Kube like APIs based on API conventions and best practices.
+        description: Kube API Linter lints Kube-like APIs based on API conventions and best practices.
   exclusions:
     rules:
       - linters:

--- a/.golangci.kube-api-linter.yaml
+++ b/.golangci.kube-api-linter.yaml
@@ -1,0 +1,16 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - kubeapilinter
+  settings:
+    custom:
+      kubeapilinter:
+        type: module
+        description: Kube API Linter lints Kube like APIs based on API conventions and best practices.
+  exclusions:
+    rules:
+      - linters:
+          - kubeapilinter
+        path-except: pkg/apis/.*

--- a/deploy/charts/approver-policy/templates/crd-policy.cert-manager.io_certificaterequestpolicies.yaml
+++ b/deploy/charts/approver-policy/templates/crd-policy.cert-manager.io_certificaterequestpolicies.yaml
@@ -57,13 +57,11 @@ spec:
             metadata:
               type: object
             spec:
-              description: |-
-                CertificateRequestPolicySpec defines the desired state of
-                CertificateRequestPolicy.
+              description: spec is the desired state of the CertificateRequestPolicy.
               properties:
                 allowed:
                   description: |-
-                    Allowed defines the allowed attributes for a CertificateRequest.
+                    allowed defines the allowed attributes for a CertificateRequest.
                     A CertificateRequest can request _less_ than what is allowed,
                     but _not more_, i.e. a CertificateRequest can request a subset of what
                     is declared as allowed by the policy.
@@ -72,17 +70,17 @@ spec:
                     permitted.
                   properties:
                     commonName:
-                      description: CommonName defines the X.509 Common Name that may be requested.
+                      description: commonName defines the X.509 Common Name that may be requested.
                       properties:
                         required:
                           description: |-
-                            Required marks that the related field must be provided and not be an
+                            required marks that the related field must be provided and not be an
                             empty string.
                             Defaults to `false`.
                           type: boolean
                         validations:
                           description: |-
-                            Validations applies rules using Common Expression Language (CEL) to
+                            validations applies rules using Common Expression Language (CEL) to
                             validate attribute value present on request beyond what is possible
                             to express using value/required.
                             An attribute value on the related CertificateRequest field must pass
@@ -92,7 +90,7 @@ spec:
                             properties:
                               message:
                                 description: |-
-                                  Message is the message to display when validation fails.
+                                  message is the message to display when validation fails.
                                   Message is required if the Rule contains line breaks. Note that Message
                                   must not contain line breaks.
                                   If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -100,7 +98,7 @@ spec:
                                 type: string
                               rule:
                                 description: |-
-                                  Rule represents the expression which will be evaluated by CEL.
+                                  rule represents the expression which will be evaluated by CEL.
                                   ref: https://github.com/google/cel-spec
                                   The Rule is scoped to the location of the validations in the schema.
                                   The `self` variable in the CEL expression is bound to the scoped value.
@@ -122,7 +120,7 @@ spec:
                           x-kubernetes-list-type: map
                         value:
                           description: |-
-                            Value defines the allowed attribute value on the related CertificateRequest field.
+                            value defines the allowed attribute value on the related CertificateRequest field.
                             Accepts wildcards "*".
                             If set, the related field must match the specified pattern.
 
@@ -131,16 +129,16 @@ spec:
                           type: string
                       type: object
                     dnsNames:
-                      description: DNSNames defines the X.509 DNS SANs that may be requested.
+                      description: dnsNames defines the X.509 DNS SANs that may be requested.
                       properties:
                         required:
                           description: |-
-                            Required controls whether the related field must have at least one value.
+                            required controls whether the related field must have at least one value.
                             Defaults to `false`.
                           type: boolean
                         validations:
                           description: |-
-                            Validations applies rules using Common Expression Language (CEL) to
+                            validations applies rules using Common Expression Language (CEL) to
                             validate attribute values present on request beyond what is possible
                             to express using values/required.
                             ALL attribute values on the related CertificateRequest field must pass
@@ -150,7 +148,7 @@ spec:
                             properties:
                               message:
                                 description: |-
-                                  Message is the message to display when validation fails.
+                                  message is the message to display when validation fails.
                                   Message is required if the Rule contains line breaks. Note that Message
                                   must not contain line breaks.
                                   If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -158,7 +156,7 @@ spec:
                                 type: string
                               rule:
                                 description: |-
-                                  Rule represents the expression which will be evaluated by CEL.
+                                  rule represents the expression which will be evaluated by CEL.
                                   ref: https://github.com/google/cel-spec
                                   The Rule is scoped to the location of the validations in the schema.
                                   The `self` variable in the CEL expression is bound to the scoped value.
@@ -180,7 +178,7 @@ spec:
                           x-kubernetes-list-type: map
                         values:
                           description: |-
-                            Values defines allowed attribute values on the related CertificateRequest field.
+                            values defines allowed attribute values on the related CertificateRequest field.
                             Accepts wildcards "*".
                             If set, the related field can only include items contained in the allowed values.
 
@@ -191,16 +189,16 @@ spec:
                           type: array
                       type: object
                     emailAddresses:
-                      description: EmailAddresses defines the X.509 Email SANs that may be requested.
+                      description: emailAddresses defines the X.509 Email SANs that may be requested.
                       properties:
                         required:
                           description: |-
-                            Required controls whether the related field must have at least one value.
+                            required controls whether the related field must have at least one value.
                             Defaults to `false`.
                           type: boolean
                         validations:
                           description: |-
-                            Validations applies rules using Common Expression Language (CEL) to
+                            validations applies rules using Common Expression Language (CEL) to
                             validate attribute values present on request beyond what is possible
                             to express using values/required.
                             ALL attribute values on the related CertificateRequest field must pass
@@ -210,7 +208,7 @@ spec:
                             properties:
                               message:
                                 description: |-
-                                  Message is the message to display when validation fails.
+                                  message is the message to display when validation fails.
                                   Message is required if the Rule contains line breaks. Note that Message
                                   must not contain line breaks.
                                   If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -218,7 +216,7 @@ spec:
                                 type: string
                               rule:
                                 description: |-
-                                  Rule represents the expression which will be evaluated by CEL.
+                                  rule represents the expression which will be evaluated by CEL.
                                   ref: https://github.com/google/cel-spec
                                   The Rule is scoped to the location of the validations in the schema.
                                   The `self` variable in the CEL expression is bound to the scoped value.
@@ -240,7 +238,7 @@ spec:
                           x-kubernetes-list-type: map
                         values:
                           description: |-
-                            Values defines allowed attribute values on the related CertificateRequest field.
+                            values defines allowed attribute values on the related CertificateRequest field.
                             Accepts wildcards "*".
                             If set, the related field can only include items contained in the allowed values.
 
@@ -251,16 +249,16 @@ spec:
                           type: array
                       type: object
                     ipAddresses:
-                      description: IPAddresses defines the X.509 IP SANs that may be requested.
+                      description: ipAddresses defines the X.509 IP SANs that may be requested.
                       properties:
                         required:
                           description: |-
-                            Required controls whether the related field must have at least one value.
+                            required controls whether the related field must have at least one value.
                             Defaults to `false`.
                           type: boolean
                         validations:
                           description: |-
-                            Validations applies rules using Common Expression Language (CEL) to
+                            validations applies rules using Common Expression Language (CEL) to
                             validate attribute values present on request beyond what is possible
                             to express using values/required.
                             ALL attribute values on the related CertificateRequest field must pass
@@ -270,7 +268,7 @@ spec:
                             properties:
                               message:
                                 description: |-
-                                  Message is the message to display when validation fails.
+                                  message is the message to display when validation fails.
                                   Message is required if the Rule contains line breaks. Note that Message
                                   must not contain line breaks.
                                   If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -278,7 +276,7 @@ spec:
                                 type: string
                               rule:
                                 description: |-
-                                  Rule represents the expression which will be evaluated by CEL.
+                                  rule represents the expression which will be evaluated by CEL.
                                   ref: https://github.com/google/cel-spec
                                   The Rule is scoped to the location of the validations in the schema.
                                   The `self` variable in the CEL expression is bound to the scoped value.
@@ -300,7 +298,7 @@ spec:
                           x-kubernetes-list-type: map
                         values:
                           description: |-
-                            Values defines allowed attribute values on the related CertificateRequest field.
+                            values defines allowed attribute values on the related CertificateRequest field.
                             Accepts wildcards "*".
                             If set, the related field can only include items contained in the allowed values.
 
@@ -312,14 +310,14 @@ spec:
                       type: object
                     isCA:
                       description: |-
-                        IsCA defines if a CertificateRequest is allowed to set the `spec.isCA`
+                        isCA defines if a CertificateRequest is allowed to set the `spec.isCA`
                         field set to `true`.
                         If `true`, the `spec.isCA` field can be `true` or `false`.
                         If `false` or unset, the `spec.isCA` field must be `false`.
                       type: boolean
                     otherNames:
                       description: |-
-                        OtherNames defines the additional SAN GeneralName otherName entries
+                        otherNames defines the additional SAN GeneralName otherName entries
                         (context tag 0) that may be present in a CertificateRequest. Each
                         entry pins a dotted ASN.1 OID (e.g. "1.3.6.1.4.1.311.20.2.3" for the
                         Microsoft User Principal Name) and constrains the allowed values for
@@ -338,19 +336,19 @@ spec:
                         properties:
                           oid:
                             description: |-
-                              OID is the dotted ASN.1 object identifier that the otherName entry
+                              oid is the dotted ASN.1 object identifier that the otherName entry
                               must carry, e.g. "1.3.6.1.4.1.311.20.2.3" for the Microsoft User
                               Principal Name.
                             type: string
                           required:
                             description: |-
-                              Required marks that at least one otherName entry with this OID must
+                              required marks that at least one otherName entry with this OID must
                               be present on the request.
                               Defaults to `false`.
                             type: boolean
                           validations:
                             description: |-
-                              Validations applies rules using Common Expression Language (CEL) to
+                              validations applies rules using Common Expression Language (CEL) to
                               validate every otherName value with the matching OID present on the
                               request beyond what is possible to express using values/required.
                             items:
@@ -358,7 +356,7 @@ spec:
                               properties:
                                 message:
                                   description: |-
-                                    Message is the message to display when validation fails.
+                                    message is the message to display when validation fails.
                                     Message is required if the Rule contains line breaks. Note that Message
                                     must not contain line breaks.
                                     If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -366,7 +364,7 @@ spec:
                                   type: string
                                 rule:
                                   description: |-
-                                    Rule represents the expression which will be evaluated by CEL.
+                                    rule represents the expression which will be evaluated by CEL.
                                     ref: https://github.com/google/cel-spec
                                     The Rule is scoped to the location of the validations in the schema.
                                     The `self` variable in the CEL expression is bound to the scoped value.
@@ -388,7 +386,7 @@ spec:
                             x-kubernetes-list-type: map
                           values:
                             description: |-
-                              Values defines the allowed values for otherName entries with this
+                              values defines the allowed values for otherName entries with this
                               OID. Accepts wildcards "*".
                               If set, every otherName entry with the matching OID present in the
                               request must be a member of this list.
@@ -404,23 +402,23 @@ spec:
                       x-kubernetes-list-type: map
                     subject:
                       description: |-
-                        Subject declares the X.509 Subject attributes allowed in a
+                        subject declares the X.509 Subject attributes allowed in a
                         CertificateRequest. An omitted field forbids any Subject attributes
                         from being requested.
                         A CertificateRequest can request a subset of the allowed X.509 Subject
                         attributes.
                       properties:
                         countries:
-                          description: Countries define the X.509 Subject Countries that may be requested.
+                          description: countries define the X.509 Subject Countries that may be requested.
                           properties:
                             required:
                               description: |-
-                                Required controls whether the related field must have at least one value.
+                                required controls whether the related field must have at least one value.
                                 Defaults to `false`.
                               type: boolean
                             validations:
                               description: |-
-                                Validations applies rules using Common Expression Language (CEL) to
+                                validations applies rules using Common Expression Language (CEL) to
                                 validate attribute values present on request beyond what is possible
                                 to express using values/required.
                                 ALL attribute values on the related CertificateRequest field must pass
@@ -430,7 +428,7 @@ spec:
                                 properties:
                                   message:
                                     description: |-
-                                      Message is the message to display when validation fails.
+                                      message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
                                       If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -438,7 +436,7 @@ spec:
                                     type: string
                                   rule:
                                     description: |-
-                                      Rule represents the expression which will be evaluated by CEL.
+                                      rule represents the expression which will be evaluated by CEL.
                                       ref: https://github.com/google/cel-spec
                                       The Rule is scoped to the location of the validations in the schema.
                                       The `self` variable in the CEL expression is bound to the scoped value.
@@ -460,7 +458,7 @@ spec:
                               x-kubernetes-list-type: map
                             values:
                               description: |-
-                                Values defines allowed attribute values on the related CertificateRequest field.
+                                values defines allowed attribute values on the related CertificateRequest field.
                                 Accepts wildcards "*".
                                 If set, the related field can only include items contained in the allowed values.
 
@@ -471,16 +469,16 @@ spec:
                               type: array
                           type: object
                         localities:
-                          description: Localities defines the X.509 Subject Localities that may be requested.
+                          description: localities defines the X.509 Subject Localities that may be requested.
                           properties:
                             required:
                               description: |-
-                                Required controls whether the related field must have at least one value.
+                                required controls whether the related field must have at least one value.
                                 Defaults to `false`.
                               type: boolean
                             validations:
                               description: |-
-                                Validations applies rules using Common Expression Language (CEL) to
+                                validations applies rules using Common Expression Language (CEL) to
                                 validate attribute values present on request beyond what is possible
                                 to express using values/required.
                                 ALL attribute values on the related CertificateRequest field must pass
@@ -490,7 +488,7 @@ spec:
                                 properties:
                                   message:
                                     description: |-
-                                      Message is the message to display when validation fails.
+                                      message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
                                       If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -498,7 +496,7 @@ spec:
                                     type: string
                                   rule:
                                     description: |-
-                                      Rule represents the expression which will be evaluated by CEL.
+                                      rule represents the expression which will be evaluated by CEL.
                                       ref: https://github.com/google/cel-spec
                                       The Rule is scoped to the location of the validations in the schema.
                                       The `self` variable in the CEL expression is bound to the scoped value.
@@ -520,7 +518,7 @@ spec:
                               x-kubernetes-list-type: map
                             values:
                               description: |-
-                                Values defines allowed attribute values on the related CertificateRequest field.
+                                values defines allowed attribute values on the related CertificateRequest field.
                                 Accepts wildcards "*".
                                 If set, the related field can only include items contained in the allowed values.
 
@@ -532,17 +530,17 @@ spec:
                           type: object
                         organizationalUnits:
                           description: |-
-                            OrganizationalUnits defines the X.509 Subject Organizational Units that
+                            organizationalUnits defines the X.509 Subject Organizational Units that
                             may be requested.
                           properties:
                             required:
                               description: |-
-                                Required controls whether the related field must have at least one value.
+                                required controls whether the related field must have at least one value.
                                 Defaults to `false`.
                               type: boolean
                             validations:
                               description: |-
-                                Validations applies rules using Common Expression Language (CEL) to
+                                validations applies rules using Common Expression Language (CEL) to
                                 validate attribute values present on request beyond what is possible
                                 to express using values/required.
                                 ALL attribute values on the related CertificateRequest field must pass
@@ -552,7 +550,7 @@ spec:
                                 properties:
                                   message:
                                     description: |-
-                                      Message is the message to display when validation fails.
+                                      message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
                                       If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -560,7 +558,7 @@ spec:
                                     type: string
                                   rule:
                                     description: |-
-                                      Rule represents the expression which will be evaluated by CEL.
+                                      rule represents the expression which will be evaluated by CEL.
                                       ref: https://github.com/google/cel-spec
                                       The Rule is scoped to the location of the validations in the schema.
                                       The `self` variable in the CEL expression is bound to the scoped value.
@@ -582,7 +580,7 @@ spec:
                               x-kubernetes-list-type: map
                             values:
                               description: |-
-                                Values defines allowed attribute values on the related CertificateRequest field.
+                                values defines allowed attribute values on the related CertificateRequest field.
                                 Accepts wildcards "*".
                                 If set, the related field can only include items contained in the allowed values.
 
@@ -594,17 +592,17 @@ spec:
                           type: object
                         organizations:
                           description: |-
-                            Organizations define the X.509 Subject Organizations that may be
+                            organizations define the X.509 Subject Organizations that may be
                             requested.
                           properties:
                             required:
                               description: |-
-                                Required controls whether the related field must have at least one value.
+                                required controls whether the related field must have at least one value.
                                 Defaults to `false`.
                               type: boolean
                             validations:
                               description: |-
-                                Validations applies rules using Common Expression Language (CEL) to
+                                validations applies rules using Common Expression Language (CEL) to
                                 validate attribute values present on request beyond what is possible
                                 to express using values/required.
                                 ALL attribute values on the related CertificateRequest field must pass
@@ -614,7 +612,7 @@ spec:
                                 properties:
                                   message:
                                     description: |-
-                                      Message is the message to display when validation fails.
+                                      message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
                                       If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -622,7 +620,7 @@ spec:
                                     type: string
                                   rule:
                                     description: |-
-                                      Rule represents the expression which will be evaluated by CEL.
+                                      rule represents the expression which will be evaluated by CEL.
                                       ref: https://github.com/google/cel-spec
                                       The Rule is scoped to the location of the validations in the schema.
                                       The `self` variable in the CEL expression is bound to the scoped value.
@@ -644,7 +642,7 @@ spec:
                               x-kubernetes-list-type: map
                             values:
                               description: |-
-                                Values defines allowed attribute values on the related CertificateRequest field.
+                                values defines allowed attribute values on the related CertificateRequest field.
                                 Accepts wildcards "*".
                                 If set, the related field can only include items contained in the allowed values.
 
@@ -656,7 +654,7 @@ spec:
                           type: object
                         otherAttributes:
                           description: |-
-                            OtherAttributes defines additional Subject RDN attribute OIDs that
+                            otherAttributes defines additional Subject RDN attribute OIDs that
                             may be present in a CertificateRequest beyond the named fields above.
                             Each entry pins a dotted ASN.1 OID (e.g. "1.2.840.113549.1.9.1" for
                             emailAddress, "0.9.2342.19200300.100.1.25" for domainComponent) and
@@ -675,18 +673,18 @@ spec:
                             properties:
                               oid:
                                 description: |-
-                                  OID is the dotted ASN.1 object identifier of the Subject RDN
+                                  oid is the dotted ASN.1 object identifier of the Subject RDN
                                   attribute, e.g. "1.2.840.113549.1.9.1" for emailAddress.
                                 type: string
                               required:
                                 description: |-
-                                  Required marks that at least one Subject RDN attribute with this OID
+                                  required marks that at least one Subject RDN attribute with this OID
                                   must be present on the request.
                                   Defaults to `false`.
                                 type: boolean
                               validations:
                                 description: |-
-                                  Validations applies rules using Common Expression Language (CEL) to
+                                  validations applies rules using Common Expression Language (CEL) to
                                   validate every Subject RDN attribute value with the matching OID
                                   present on the request beyond what is possible to express using
                                   values/required.
@@ -695,7 +693,7 @@ spec:
                                   properties:
                                     message:
                                       description: |-
-                                        Message is the message to display when validation fails.
+                                        message is the message to display when validation fails.
                                         Message is required if the Rule contains line breaks. Note that Message
                                         must not contain line breaks.
                                         If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -703,7 +701,7 @@ spec:
                                       type: string
                                     rule:
                                       description: |-
-                                        Rule represents the expression which will be evaluated by CEL.
+                                        rule represents the expression which will be evaluated by CEL.
                                         ref: https://github.com/google/cel-spec
                                         The Rule is scoped to the location of the validations in the schema.
                                         The `self` variable in the CEL expression is bound to the scoped value.
@@ -725,7 +723,7 @@ spec:
                                 x-kubernetes-list-type: map
                               values:
                                 description: |-
-                                  Values defines the allowed values for Subject RDN attributes with
+                                  values defines the allowed values for Subject RDN attributes with
                                   this OID. Accepts wildcards "*".
                                   If set, every Subject RDN attribute with the matching OID present in
                                   the request must be a member of this list.
@@ -740,16 +738,16 @@ spec:
                             - oid
                           x-kubernetes-list-type: map
                         postalCodes:
-                          description: PostalCodes defines the X.509 Subject Postal Codes that may be requested.
+                          description: postalCodes defines the X.509 Subject Postal Codes that may be requested.
                           properties:
                             required:
                               description: |-
-                                Required controls whether the related field must have at least one value.
+                                required controls whether the related field must have at least one value.
                                 Defaults to `false`.
                               type: boolean
                             validations:
                               description: |-
-                                Validations applies rules using Common Expression Language (CEL) to
+                                validations applies rules using Common Expression Language (CEL) to
                                 validate attribute values present on request beyond what is possible
                                 to express using values/required.
                                 ALL attribute values on the related CertificateRequest field must pass
@@ -759,7 +757,7 @@ spec:
                                 properties:
                                   message:
                                     description: |-
-                                      Message is the message to display when validation fails.
+                                      message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
                                       If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -767,7 +765,7 @@ spec:
                                     type: string
                                   rule:
                                     description: |-
-                                      Rule represents the expression which will be evaluated by CEL.
+                                      rule represents the expression which will be evaluated by CEL.
                                       ref: https://github.com/google/cel-spec
                                       The Rule is scoped to the location of the validations in the schema.
                                       The `self` variable in the CEL expression is bound to the scoped value.
@@ -789,7 +787,7 @@ spec:
                               x-kubernetes-list-type: map
                             values:
                               description: |-
-                                Values defines allowed attribute values on the related CertificateRequest field.
+                                values defines allowed attribute values on the related CertificateRequest field.
                                 Accepts wildcards "*".
                                 If set, the related field can only include items contained in the allowed values.
 
@@ -800,16 +798,16 @@ spec:
                               type: array
                           type: object
                         provinces:
-                          description: Provinces defines the X.509 Subject Provinces that may be requested.
+                          description: provinces defines the X.509 Subject Provinces that may be requested.
                           properties:
                             required:
                               description: |-
-                                Required controls whether the related field must have at least one value.
+                                required controls whether the related field must have at least one value.
                                 Defaults to `false`.
                               type: boolean
                             validations:
                               description: |-
-                                Validations applies rules using Common Expression Language (CEL) to
+                                validations applies rules using Common Expression Language (CEL) to
                                 validate attribute values present on request beyond what is possible
                                 to express using values/required.
                                 ALL attribute values on the related CertificateRequest field must pass
@@ -819,7 +817,7 @@ spec:
                                 properties:
                                   message:
                                     description: |-
-                                      Message is the message to display when validation fails.
+                                      message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
                                       If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -827,7 +825,7 @@ spec:
                                     type: string
                                   rule:
                                     description: |-
-                                      Rule represents the expression which will be evaluated by CEL.
+                                      rule represents the expression which will be evaluated by CEL.
                                       ref: https://github.com/google/cel-spec
                                       The Rule is scoped to the location of the validations in the schema.
                                       The `self` variable in the CEL expression is bound to the scoped value.
@@ -849,7 +847,7 @@ spec:
                               x-kubernetes-list-type: map
                             values:
                               description: |-
-                                Values defines allowed attribute values on the related CertificateRequest field.
+                                values defines allowed attribute values on the related CertificateRequest field.
                                 Accepts wildcards "*".
                                 If set, the related field can only include items contained in the allowed values.
 
@@ -861,18 +859,18 @@ spec:
                           type: object
                         serialNumber:
                           description: |-
-                            SerialNumber defines the X.509 Subject Serial Number that may be
+                            serialNumber defines the X.509 Subject Serial Number that may be
                             requested.
                           properties:
                             required:
                               description: |-
-                                Required marks that the related field must be provided and not be an
+                                required marks that the related field must be provided and not be an
                                 empty string.
                                 Defaults to `false`.
                               type: boolean
                             validations:
                               description: |-
-                                Validations applies rules using Common Expression Language (CEL) to
+                                validations applies rules using Common Expression Language (CEL) to
                                 validate attribute value present on request beyond what is possible
                                 to express using value/required.
                                 An attribute value on the related CertificateRequest field must pass
@@ -882,7 +880,7 @@ spec:
                                 properties:
                                   message:
                                     description: |-
-                                      Message is the message to display when validation fails.
+                                      message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
                                       If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -890,7 +888,7 @@ spec:
                                     type: string
                                   rule:
                                     description: |-
-                                      Rule represents the expression which will be evaluated by CEL.
+                                      rule represents the expression which will be evaluated by CEL.
                                       ref: https://github.com/google/cel-spec
                                       The Rule is scoped to the location of the validations in the schema.
                                       The `self` variable in the CEL expression is bound to the scoped value.
@@ -912,7 +910,7 @@ spec:
                               x-kubernetes-list-type: map
                             value:
                               description: |-
-                                Value defines the allowed attribute value on the related CertificateRequest field.
+                                value defines the allowed attribute value on the related CertificateRequest field.
                                 Accepts wildcards "*".
                                 If set, the related field must match the specified pattern.
 
@@ -922,17 +920,17 @@ spec:
                           type: object
                         streetAddresses:
                           description: |-
-                            StreetAddresses defines the X.509 Subject Street Addresses that may be
+                            streetAddresses defines the X.509 Subject Street Addresses that may be
                             requested.
                           properties:
                             required:
                               description: |-
-                                Required controls whether the related field must have at least one value.
+                                required controls whether the related field must have at least one value.
                                 Defaults to `false`.
                               type: boolean
                             validations:
                               description: |-
-                                Validations applies rules using Common Expression Language (CEL) to
+                                validations applies rules using Common Expression Language (CEL) to
                                 validate attribute values present on request beyond what is possible
                                 to express using values/required.
                                 ALL attribute values on the related CertificateRequest field must pass
@@ -942,7 +940,7 @@ spec:
                                 properties:
                                   message:
                                     description: |-
-                                      Message is the message to display when validation fails.
+                                      message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
                                       If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -950,7 +948,7 @@ spec:
                                     type: string
                                   rule:
                                     description: |-
-                                      Rule represents the expression which will be evaluated by CEL.
+                                      rule represents the expression which will be evaluated by CEL.
                                       ref: https://github.com/google/cel-spec
                                       The Rule is scoped to the location of the validations in the schema.
                                       The `self` variable in the CEL expression is bound to the scoped value.
@@ -972,7 +970,7 @@ spec:
                               x-kubernetes-list-type: map
                             values:
                               description: |-
-                                Values defines allowed attribute values on the related CertificateRequest field.
+                                values defines allowed attribute values on the related CertificateRequest field.
                                 Accepts wildcards "*".
                                 If set, the related field can only include items contained in the allowed values.
 
@@ -984,16 +982,16 @@ spec:
                           type: object
                       type: object
                     uris:
-                      description: URIs defines the X.509 URI SANs that may be requested.
+                      description: uris defines the X.509 URI SANs that may be requested.
                       properties:
                         required:
                           description: |-
-                            Required controls whether the related field must have at least one value.
+                            required controls whether the related field must have at least one value.
                             Defaults to `false`.
                           type: boolean
                         validations:
                           description: |-
-                            Validations applies rules using Common Expression Language (CEL) to
+                            validations applies rules using Common Expression Language (CEL) to
                             validate attribute values present on request beyond what is possible
                             to express using values/required.
                             ALL attribute values on the related CertificateRequest field must pass
@@ -1003,7 +1001,7 @@ spec:
                             properties:
                               message:
                                 description: |-
-                                  Message is the message to display when validation fails.
+                                  message is the message to display when validation fails.
                                   Message is required if the Rule contains line breaks. Note that Message
                                   must not contain line breaks.
                                   If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -1011,7 +1009,7 @@ spec:
                                 type: string
                               rule:
                                 description: |-
-                                  Rule represents the expression which will be evaluated by CEL.
+                                  rule represents the expression which will be evaluated by CEL.
                                   ref: https://github.com/google/cel-spec
                                   The Rule is scoped to the location of the validations in the schema.
                                   The `self` variable in the CEL expression is bound to the scoped value.
@@ -1033,7 +1031,7 @@ spec:
                           x-kubernetes-list-type: map
                         values:
                           description: |-
-                            Values defines allowed attribute values on the related CertificateRequest field.
+                            values defines allowed attribute values on the related CertificateRequest field.
                             Accepts wildcards "*".
                             If set, the related field can only include items contained in the allowed values.
 
@@ -1045,7 +1043,7 @@ spec:
                       type: object
                     usages:
                       description: |-
-                        Usages defines the key usages that may be included in a
+                        usages defines the key usages that may be included in a
                         CertificateRequest `spec.keyUsages` field.
                         If set, `spec.keyUsages` in a CertificateRequest must be a subset of the
                         specified values.
@@ -1110,14 +1108,14 @@ spec:
                   type: object
                 constraints:
                   description: |-
-                    Constraints define fields that _must_ be satisfied by a
+                    constraints define fields that _must_ be satisfied by a
                     CertificateRequest for the request to be allowed by this policy.
                     Omitted fields place no restrictions on the corresponding
                     attribute in a request.
                   properties:
                     maxDuration:
                       description: |-
-                        MaxDuration defines the maximum duration for a certificate request.
+                        maxDuration defines the maximum duration for a certificate request.
                         Values are inclusive (i.e. a value of `1h` will accept a duration of
                         `1h`). MinDuration and MaxDuration may be the same value.
                         If set, a duration _must_ be requested in the CertificateRequest.
@@ -1125,7 +1123,7 @@ spec:
                       type: string
                     minDuration:
                       description: |-
-                        MinDuration defines the minimum duration for a certificate request.
+                        minDuration defines the minimum duration for a certificate request.
                         Values are inclusive (i.e. a value of `1h` will accept a duration of
                         `1h`). MinDuration and MaxDuration may be the same value.
                         If set, a duration _must_ be requested in the CertificateRequest.
@@ -1133,13 +1131,13 @@ spec:
                       type: string
                     privateKey:
                       description: |-
-                        PrivateKey defines constraints on the shape of private key
+                        privateKey defines constraints on the shape of private key
                         allowed for a CertificateRequest.
                         An omitted field applies no private key shape constraints.
                       properties:
                         algorithm:
                           description: |-
-                            Algorithm defines the allowed crypto algorithm for the private key
+                            algorithm defines the allowed crypto algorithm for the private key
                             in a request.
                             An omitted field permits any algorithm.
                           enum:
@@ -1149,14 +1147,14 @@ spec:
                           type: string
                         maxSize:
                           description: |-
-                            MaxSize defines the maximum key size for a private key.
+                            maxSize defines the maximum key size for a private key.
                             Values are inclusive (i.e. a min value of `2048` will accept a size
                             of `2048`). MaxSize and MinSize may be the same value.
                             An omitted field applies no maximum constraint on size.
                           type: integer
                         minSize:
                           description: |-
-                            MinSize defines the minimum key size for a private key.
+                            minSize defines the minimum key size for a private key.
                             Values are inclusive (i.e. a min value of `2048` will accept a size
                             of `2048`). MinSize and MaxSize may be the same value.
                             An omitted field applies no minimum constraint on size.
@@ -1173,13 +1171,13 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          Values define a set of well-known, to the plugin, key value pairs that
+                          values define a set of well-known, to the plugin, key value pairs that
                           are required for the plugin to successfully evaluate a request based on
                           this policy.
                         type: object
                     type: object
                   description: |-
-                    Plugins are approvers that are built into approver-policy at
+                    plugins are approvers that are built into approver-policy at
                     compile-time. This is an advanced feature typically used to extend
                     approver-policy core features. This field define plugins and their
                     configuration that should be executed when this policy is evaluated
@@ -1187,13 +1185,13 @@ spec:
                   type: object
                 selector:
                   description: |-
-                    Selector is used for selecting over which CertificateRequests this
+                    selector is used for selecting over which CertificateRequests this
                     CertificateRequestPolicy is appropriate for and so will be used for its
                     approval evaluation.
                   properties:
                     issuerRef:
                       description: |-
-                        IssuerRef is used to match by issuer, meaning the
+                        issuerRef is used to match by issuer, meaning the
                         CertificateRequestPolicy will only evaluate CertificateRequests
                         referring to matching issuers.
                         CertificateRequests will not be processed if the issuer does not match,
@@ -1206,21 +1204,21 @@ spec:
                       properties:
                         group:
                           description: |-
-                            Group is the wildcard selector to match the `spec.issuerRef.group` field
+                            group is the wildcard selector to match the `spec.issuerRef.group` field
                             on requests.
                             Accepts wildcards "*".
                             An omitted field matches all groups.
                           type: string
                         kind:
                           description: |-
-                            Kind is the wildcard selector to match the `spec.issuerRef.kind` field
+                            kind is the wildcard selector to match the `spec.issuerRef.kind` field
                             on requests.
                             Accepts wildcards "*".
                             An omitted field matches all kinds.
                           type: string
                         name:
                           description: |-
-                            Name is a wildcard enabled selector that matches the
+                            name is a wildcard enabled selector that matches the
                             `spec.issuerRef.name` field of requests.
                             Accepts wildcards "*".
                             An omitted field matches all names.
@@ -1228,7 +1226,7 @@ spec:
                       type: object
                     namespace:
                       description: |-
-                        Namespace is used to match by namespace, meaning the
+                        namespace is used to match by namespace, meaning the
                         CertificateRequestPolicy will only match CertificateRequests
                         created in matching namespaces.
                         If this field is omitted, resources in all namespaces are checked.
@@ -1237,13 +1235,13 @@ spec:
                           additionalProperties:
                             type: string
                           description: |-
-                            MatchLabels is the set of Namespace labels that select on
+                            matchLabels is the set of Namespace labels that select on
                             CertificateRequests which have been created in a namespace matching the
                             selector.
                           type: object
                         matchNames:
                           description: |-
-                            MatchNames is the set of namespace names that select on
+                            matchNames is the set of namespace names that select on
                             CertificateRequests that have been created in a matching namespace.
                             Accepts wildcards "*".
                           items:
@@ -1255,13 +1253,11 @@ spec:
                 - selector
               type: object
             status:
-              description: |-
-                CertificateRequestPolicyStatus defines the observed state of the
-                CertificateRequestPolicy.
+              description: status is the observed state of the CertificateRequestPolicy.
               properties:
                 conditions:
                   description: |-
-                    List of status conditions to indicate the status of the
+                    conditions is a list of status conditions to indicate the status of the
                     CertificateRequestPolicy.
                     Known condition types are `Ready`.
                   items:
@@ -1322,8 +1318,6 @@ spec:
                     - type
                   x-kubernetes-list-type: map
               type: object
-          required:
-            - spec
           type: object
       served: true
       storage: true

--- a/deploy/charts/approver-policy/templates/crd-policy.cert-manager.io_certificaterequestpolicies.yaml
+++ b/deploy/charts/approver-policy/templates/crd-policy.cert-manager.io_certificaterequestpolicies.yaml
@@ -1318,6 +1318,8 @@ spec:
                     - type
                   x-kubernetes-list-type: map
               type: object
+          required:
+            - spec
           type: object
       served: true
       storage: true

--- a/deploy/charts/approver-policy/templates/crd-policy.cert-manager.io_certificaterequestpolicies.yaml
+++ b/deploy/charts/approver-policy/templates/crd-policy.cert-manager.io_certificaterequestpolicies.yaml
@@ -1179,7 +1179,7 @@ spec:
                   description: |-
                     plugins are approvers that are built into approver-policy at
                     compile-time. This is an advanced feature typically used to extend
-                    approver-policy core features. This field define plugins and their
+                    approver-policy core features. This field defines plugins and their
                     configuration that should be executed when this policy is evaluated
                     against a CertificateRequest.
                   type: object

--- a/deploy/crds/policy.cert-manager.io_certificaterequestpolicies.yaml
+++ b/deploy/crds/policy.cert-manager.io_certificaterequestpolicies.yaml
@@ -1337,6 +1337,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/deploy/crds/policy.cert-manager.io_certificaterequestpolicies.yaml
+++ b/deploy/crds/policy.cert-manager.io_certificaterequestpolicies.yaml
@@ -1197,7 +1197,7 @@ spec:
                 description: |-
                   plugins are approvers that are built into approver-policy at
                   compile-time. This is an advanced feature typically used to extend
-                  approver-policy core features. This field define plugins and their
+                  approver-policy core features. This field defines plugins and their
                   configuration that should be executed when this policy is evaluated
                   against a CertificateRequest.
                 type: object

--- a/deploy/crds/policy.cert-manager.io_certificaterequestpolicies.yaml
+++ b/deploy/crds/policy.cert-manager.io_certificaterequestpolicies.yaml
@@ -53,13 +53,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: |-
-              CertificateRequestPolicySpec defines the desired state of
-              CertificateRequestPolicy.
+            description: spec is the desired state of the CertificateRequestPolicy.
             properties:
               allowed:
                 description: |-
-                  Allowed defines the allowed attributes for a CertificateRequest.
+                  allowed defines the allowed attributes for a CertificateRequest.
                   A CertificateRequest can request _less_ than what is allowed,
                   but _not more_, i.e. a CertificateRequest can request a subset of what
                   is declared as allowed by the policy.
@@ -68,18 +66,18 @@ spec:
                   permitted.
                 properties:
                   commonName:
-                    description: CommonName defines the X.509 Common Name that may
+                    description: commonName defines the X.509 Common Name that may
                       be requested.
                     properties:
                       required:
                         description: |-
-                          Required marks that the related field must be provided and not be an
+                          required marks that the related field must be provided and not be an
                           empty string.
                           Defaults to `false`.
                         type: boolean
                       validations:
                         description: |-
-                          Validations applies rules using Common Expression Language (CEL) to
+                          validations applies rules using Common Expression Language (CEL) to
                           validate attribute value present on request beyond what is possible
                           to express using value/required.
                           An attribute value on the related CertificateRequest field must pass
@@ -90,7 +88,7 @@ spec:
                           properties:
                             message:
                               description: |-
-                                Message is the message to display when validation fails.
+                                message is the message to display when validation fails.
                                 Message is required if the Rule contains line breaks. Note that Message
                                 must not contain line breaks.
                                 If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -98,7 +96,7 @@ spec:
                               type: string
                             rule:
                               description: |-
-                                Rule represents the expression which will be evaluated by CEL.
+                                rule represents the expression which will be evaluated by CEL.
                                 ref: https://github.com/google/cel-spec
                                 The Rule is scoped to the location of the validations in the schema.
                                 The `self` variable in the CEL expression is bound to the scoped value.
@@ -120,7 +118,7 @@ spec:
                         x-kubernetes-list-type: map
                       value:
                         description: |-
-                          Value defines the allowed attribute value on the related CertificateRequest field.
+                          value defines the allowed attribute value on the related CertificateRequest field.
                           Accepts wildcards "*".
                           If set, the related field must match the specified pattern.
 
@@ -129,16 +127,16 @@ spec:
                         type: string
                     type: object
                   dnsNames:
-                    description: DNSNames defines the X.509 DNS SANs that may be requested.
+                    description: dnsNames defines the X.509 DNS SANs that may be requested.
                     properties:
                       required:
                         description: |-
-                          Required controls whether the related field must have at least one value.
+                          required controls whether the related field must have at least one value.
                           Defaults to `false`.
                         type: boolean
                       validations:
                         description: |-
-                          Validations applies rules using Common Expression Language (CEL) to
+                          validations applies rules using Common Expression Language (CEL) to
                           validate attribute values present on request beyond what is possible
                           to express using values/required.
                           ALL attribute values on the related CertificateRequest field must pass
@@ -149,7 +147,7 @@ spec:
                           properties:
                             message:
                               description: |-
-                                Message is the message to display when validation fails.
+                                message is the message to display when validation fails.
                                 Message is required if the Rule contains line breaks. Note that Message
                                 must not contain line breaks.
                                 If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -157,7 +155,7 @@ spec:
                               type: string
                             rule:
                               description: |-
-                                Rule represents the expression which will be evaluated by CEL.
+                                rule represents the expression which will be evaluated by CEL.
                                 ref: https://github.com/google/cel-spec
                                 The Rule is scoped to the location of the validations in the schema.
                                 The `self` variable in the CEL expression is bound to the scoped value.
@@ -179,7 +177,7 @@ spec:
                         x-kubernetes-list-type: map
                       values:
                         description: |-
-                          Values defines allowed attribute values on the related CertificateRequest field.
+                          values defines allowed attribute values on the related CertificateRequest field.
                           Accepts wildcards "*".
                           If set, the related field can only include items contained in the allowed values.
 
@@ -190,17 +188,17 @@ spec:
                         type: array
                     type: object
                   emailAddresses:
-                    description: EmailAddresses defines the X.509 Email SANs that
+                    description: emailAddresses defines the X.509 Email SANs that
                       may be requested.
                     properties:
                       required:
                         description: |-
-                          Required controls whether the related field must have at least one value.
+                          required controls whether the related field must have at least one value.
                           Defaults to `false`.
                         type: boolean
                       validations:
                         description: |-
-                          Validations applies rules using Common Expression Language (CEL) to
+                          validations applies rules using Common Expression Language (CEL) to
                           validate attribute values present on request beyond what is possible
                           to express using values/required.
                           ALL attribute values on the related CertificateRequest field must pass
@@ -211,7 +209,7 @@ spec:
                           properties:
                             message:
                               description: |-
-                                Message is the message to display when validation fails.
+                                message is the message to display when validation fails.
                                 Message is required if the Rule contains line breaks. Note that Message
                                 must not contain line breaks.
                                 If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -219,7 +217,7 @@ spec:
                               type: string
                             rule:
                               description: |-
-                                Rule represents the expression which will be evaluated by CEL.
+                                rule represents the expression which will be evaluated by CEL.
                                 ref: https://github.com/google/cel-spec
                                 The Rule is scoped to the location of the validations in the schema.
                                 The `self` variable in the CEL expression is bound to the scoped value.
@@ -241,7 +239,7 @@ spec:
                         x-kubernetes-list-type: map
                       values:
                         description: |-
-                          Values defines allowed attribute values on the related CertificateRequest field.
+                          values defines allowed attribute values on the related CertificateRequest field.
                           Accepts wildcards "*".
                           If set, the related field can only include items contained in the allowed values.
 
@@ -252,17 +250,17 @@ spec:
                         type: array
                     type: object
                   ipAddresses:
-                    description: IPAddresses defines the X.509 IP SANs that may be
+                    description: ipAddresses defines the X.509 IP SANs that may be
                       requested.
                     properties:
                       required:
                         description: |-
-                          Required controls whether the related field must have at least one value.
+                          required controls whether the related field must have at least one value.
                           Defaults to `false`.
                         type: boolean
                       validations:
                         description: |-
-                          Validations applies rules using Common Expression Language (CEL) to
+                          validations applies rules using Common Expression Language (CEL) to
                           validate attribute values present on request beyond what is possible
                           to express using values/required.
                           ALL attribute values on the related CertificateRequest field must pass
@@ -273,7 +271,7 @@ spec:
                           properties:
                             message:
                               description: |-
-                                Message is the message to display when validation fails.
+                                message is the message to display when validation fails.
                                 Message is required if the Rule contains line breaks. Note that Message
                                 must not contain line breaks.
                                 If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -281,7 +279,7 @@ spec:
                               type: string
                             rule:
                               description: |-
-                                Rule represents the expression which will be evaluated by CEL.
+                                rule represents the expression which will be evaluated by CEL.
                                 ref: https://github.com/google/cel-spec
                                 The Rule is scoped to the location of the validations in the schema.
                                 The `self` variable in the CEL expression is bound to the scoped value.
@@ -303,7 +301,7 @@ spec:
                         x-kubernetes-list-type: map
                       values:
                         description: |-
-                          Values defines allowed attribute values on the related CertificateRequest field.
+                          values defines allowed attribute values on the related CertificateRequest field.
                           Accepts wildcards "*".
                           If set, the related field can only include items contained in the allowed values.
 
@@ -315,14 +313,14 @@ spec:
                     type: object
                   isCA:
                     description: |-
-                      IsCA defines if a CertificateRequest is allowed to set the `spec.isCA`
+                      isCA defines if a CertificateRequest is allowed to set the `spec.isCA`
                       field set to `true`.
                       If `true`, the `spec.isCA` field can be `true` or `false`.
                       If `false` or unset, the `spec.isCA` field must be `false`.
                     type: boolean
                   otherNames:
                     description: |-
-                      OtherNames defines the additional SAN GeneralName otherName entries
+                      otherNames defines the additional SAN GeneralName otherName entries
                       (context tag 0) that may be present in a CertificateRequest. Each
                       entry pins a dotted ASN.1 OID (e.g. "1.3.6.1.4.1.311.20.2.3" for the
                       Microsoft User Principal Name) and constrains the allowed values for
@@ -341,19 +339,19 @@ spec:
                       properties:
                         oid:
                           description: |-
-                            OID is the dotted ASN.1 object identifier that the otherName entry
+                            oid is the dotted ASN.1 object identifier that the otherName entry
                             must carry, e.g. "1.3.6.1.4.1.311.20.2.3" for the Microsoft User
                             Principal Name.
                           type: string
                         required:
                           description: |-
-                            Required marks that at least one otherName entry with this OID must
+                            required marks that at least one otherName entry with this OID must
                             be present on the request.
                             Defaults to `false`.
                           type: boolean
                         validations:
                           description: |-
-                            Validations applies rules using Common Expression Language (CEL) to
+                            validations applies rules using Common Expression Language (CEL) to
                             validate every otherName value with the matching OID present on the
                             request beyond what is possible to express using values/required.
                           items:
@@ -362,7 +360,7 @@ spec:
                             properties:
                               message:
                                 description: |-
-                                  Message is the message to display when validation fails.
+                                  message is the message to display when validation fails.
                                   Message is required if the Rule contains line breaks. Note that Message
                                   must not contain line breaks.
                                   If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -370,7 +368,7 @@ spec:
                                 type: string
                               rule:
                                 description: |-
-                                  Rule represents the expression which will be evaluated by CEL.
+                                  rule represents the expression which will be evaluated by CEL.
                                   ref: https://github.com/google/cel-spec
                                   The Rule is scoped to the location of the validations in the schema.
                                   The `self` variable in the CEL expression is bound to the scoped value.
@@ -392,7 +390,7 @@ spec:
                           x-kubernetes-list-type: map
                         values:
                           description: |-
-                            Values defines the allowed values for otherName entries with this
+                            values defines the allowed values for otherName entries with this
                             OID. Accepts wildcards "*".
                             If set, every otherName entry with the matching OID present in the
                             request must be a member of this list.
@@ -408,24 +406,24 @@ spec:
                     x-kubernetes-list-type: map
                   subject:
                     description: |-
-                      Subject declares the X.509 Subject attributes allowed in a
+                      subject declares the X.509 Subject attributes allowed in a
                       CertificateRequest. An omitted field forbids any Subject attributes
                       from being requested.
                       A CertificateRequest can request a subset of the allowed X.509 Subject
                       attributes.
                     properties:
                       countries:
-                        description: Countries define the X.509 Subject Countries
+                        description: countries define the X.509 Subject Countries
                           that may be requested.
                         properties:
                           required:
                             description: |-
-                              Required controls whether the related field must have at least one value.
+                              required controls whether the related field must have at least one value.
                               Defaults to `false`.
                             type: boolean
                           validations:
                             description: |-
-                              Validations applies rules using Common Expression Language (CEL) to
+                              validations applies rules using Common Expression Language (CEL) to
                               validate attribute values present on request beyond what is possible
                               to express using values/required.
                               ALL attribute values on the related CertificateRequest field must pass
@@ -436,7 +434,7 @@ spec:
                               properties:
                                 message:
                                   description: |-
-                                    Message is the message to display when validation fails.
+                                    message is the message to display when validation fails.
                                     Message is required if the Rule contains line breaks. Note that Message
                                     must not contain line breaks.
                                     If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -444,7 +442,7 @@ spec:
                                   type: string
                                 rule:
                                   description: |-
-                                    Rule represents the expression which will be evaluated by CEL.
+                                    rule represents the expression which will be evaluated by CEL.
                                     ref: https://github.com/google/cel-spec
                                     The Rule is scoped to the location of the validations in the schema.
                                     The `self` variable in the CEL expression is bound to the scoped value.
@@ -466,7 +464,7 @@ spec:
                             x-kubernetes-list-type: map
                           values:
                             description: |-
-                              Values defines allowed attribute values on the related CertificateRequest field.
+                              values defines allowed attribute values on the related CertificateRequest field.
                               Accepts wildcards "*".
                               If set, the related field can only include items contained in the allowed values.
 
@@ -477,17 +475,17 @@ spec:
                             type: array
                         type: object
                       localities:
-                        description: Localities defines the X.509 Subject Localities
+                        description: localities defines the X.509 Subject Localities
                           that may be requested.
                         properties:
                           required:
                             description: |-
-                              Required controls whether the related field must have at least one value.
+                              required controls whether the related field must have at least one value.
                               Defaults to `false`.
                             type: boolean
                           validations:
                             description: |-
-                              Validations applies rules using Common Expression Language (CEL) to
+                              validations applies rules using Common Expression Language (CEL) to
                               validate attribute values present on request beyond what is possible
                               to express using values/required.
                               ALL attribute values on the related CertificateRequest field must pass
@@ -498,7 +496,7 @@ spec:
                               properties:
                                 message:
                                   description: |-
-                                    Message is the message to display when validation fails.
+                                    message is the message to display when validation fails.
                                     Message is required if the Rule contains line breaks. Note that Message
                                     must not contain line breaks.
                                     If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -506,7 +504,7 @@ spec:
                                   type: string
                                 rule:
                                   description: |-
-                                    Rule represents the expression which will be evaluated by CEL.
+                                    rule represents the expression which will be evaluated by CEL.
                                     ref: https://github.com/google/cel-spec
                                     The Rule is scoped to the location of the validations in the schema.
                                     The `self` variable in the CEL expression is bound to the scoped value.
@@ -528,7 +526,7 @@ spec:
                             x-kubernetes-list-type: map
                           values:
                             description: |-
-                              Values defines allowed attribute values on the related CertificateRequest field.
+                              values defines allowed attribute values on the related CertificateRequest field.
                               Accepts wildcards "*".
                               If set, the related field can only include items contained in the allowed values.
 
@@ -540,17 +538,17 @@ spec:
                         type: object
                       organizationalUnits:
                         description: |-
-                          OrganizationalUnits defines the X.509 Subject Organizational Units that
+                          organizationalUnits defines the X.509 Subject Organizational Units that
                           may be requested.
                         properties:
                           required:
                             description: |-
-                              Required controls whether the related field must have at least one value.
+                              required controls whether the related field must have at least one value.
                               Defaults to `false`.
                             type: boolean
                           validations:
                             description: |-
-                              Validations applies rules using Common Expression Language (CEL) to
+                              validations applies rules using Common Expression Language (CEL) to
                               validate attribute values present on request beyond what is possible
                               to express using values/required.
                               ALL attribute values on the related CertificateRequest field must pass
@@ -561,7 +559,7 @@ spec:
                               properties:
                                 message:
                                   description: |-
-                                    Message is the message to display when validation fails.
+                                    message is the message to display when validation fails.
                                     Message is required if the Rule contains line breaks. Note that Message
                                     must not contain line breaks.
                                     If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -569,7 +567,7 @@ spec:
                                   type: string
                                 rule:
                                   description: |-
-                                    Rule represents the expression which will be evaluated by CEL.
+                                    rule represents the expression which will be evaluated by CEL.
                                     ref: https://github.com/google/cel-spec
                                     The Rule is scoped to the location of the validations in the schema.
                                     The `self` variable in the CEL expression is bound to the scoped value.
@@ -591,7 +589,7 @@ spec:
                             x-kubernetes-list-type: map
                           values:
                             description: |-
-                              Values defines allowed attribute values on the related CertificateRequest field.
+                              values defines allowed attribute values on the related CertificateRequest field.
                               Accepts wildcards "*".
                               If set, the related field can only include items contained in the allowed values.
 
@@ -603,17 +601,17 @@ spec:
                         type: object
                       organizations:
                         description: |-
-                          Organizations define the X.509 Subject Organizations that may be
+                          organizations define the X.509 Subject Organizations that may be
                           requested.
                         properties:
                           required:
                             description: |-
-                              Required controls whether the related field must have at least one value.
+                              required controls whether the related field must have at least one value.
                               Defaults to `false`.
                             type: boolean
                           validations:
                             description: |-
-                              Validations applies rules using Common Expression Language (CEL) to
+                              validations applies rules using Common Expression Language (CEL) to
                               validate attribute values present on request beyond what is possible
                               to express using values/required.
                               ALL attribute values on the related CertificateRequest field must pass
@@ -624,7 +622,7 @@ spec:
                               properties:
                                 message:
                                   description: |-
-                                    Message is the message to display when validation fails.
+                                    message is the message to display when validation fails.
                                     Message is required if the Rule contains line breaks. Note that Message
                                     must not contain line breaks.
                                     If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -632,7 +630,7 @@ spec:
                                   type: string
                                 rule:
                                   description: |-
-                                    Rule represents the expression which will be evaluated by CEL.
+                                    rule represents the expression which will be evaluated by CEL.
                                     ref: https://github.com/google/cel-spec
                                     The Rule is scoped to the location of the validations in the schema.
                                     The `self` variable in the CEL expression is bound to the scoped value.
@@ -654,7 +652,7 @@ spec:
                             x-kubernetes-list-type: map
                           values:
                             description: |-
-                              Values defines allowed attribute values on the related CertificateRequest field.
+                              values defines allowed attribute values on the related CertificateRequest field.
                               Accepts wildcards "*".
                               If set, the related field can only include items contained in the allowed values.
 
@@ -666,7 +664,7 @@ spec:
                         type: object
                       otherAttributes:
                         description: |-
-                          OtherAttributes defines additional Subject RDN attribute OIDs that
+                          otherAttributes defines additional Subject RDN attribute OIDs that
                           may be present in a CertificateRequest beyond the named fields above.
                           Each entry pins a dotted ASN.1 OID (e.g. "1.2.840.113549.1.9.1" for
                           emailAddress, "0.9.2342.19200300.100.1.25" for domainComponent) and
@@ -685,18 +683,18 @@ spec:
                           properties:
                             oid:
                               description: |-
-                                OID is the dotted ASN.1 object identifier of the Subject RDN
+                                oid is the dotted ASN.1 object identifier of the Subject RDN
                                 attribute, e.g. "1.2.840.113549.1.9.1" for emailAddress.
                               type: string
                             required:
                               description: |-
-                                Required marks that at least one Subject RDN attribute with this OID
+                                required marks that at least one Subject RDN attribute with this OID
                                 must be present on the request.
                                 Defaults to `false`.
                               type: boolean
                             validations:
                               description: |-
-                                Validations applies rules using Common Expression Language (CEL) to
+                                validations applies rules using Common Expression Language (CEL) to
                                 validate every Subject RDN attribute value with the matching OID
                                 present on the request beyond what is possible to express using
                                 values/required.
@@ -706,7 +704,7 @@ spec:
                                 properties:
                                   message:
                                     description: |-
-                                      Message is the message to display when validation fails.
+                                      message is the message to display when validation fails.
                                       Message is required if the Rule contains line breaks. Note that Message
                                       must not contain line breaks.
                                       If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -714,7 +712,7 @@ spec:
                                     type: string
                                   rule:
                                     description: |-
-                                      Rule represents the expression which will be evaluated by CEL.
+                                      rule represents the expression which will be evaluated by CEL.
                                       ref: https://github.com/google/cel-spec
                                       The Rule is scoped to the location of the validations in the schema.
                                       The `self` variable in the CEL expression is bound to the scoped value.
@@ -736,7 +734,7 @@ spec:
                               x-kubernetes-list-type: map
                             values:
                               description: |-
-                                Values defines the allowed values for Subject RDN attributes with
+                                values defines the allowed values for Subject RDN attributes with
                                 this OID. Accepts wildcards "*".
                                 If set, every Subject RDN attribute with the matching OID present in
                                 the request must be a member of this list.
@@ -751,17 +749,17 @@ spec:
                         - oid
                         x-kubernetes-list-type: map
                       postalCodes:
-                        description: PostalCodes defines the X.509 Subject Postal
+                        description: postalCodes defines the X.509 Subject Postal
                           Codes that may be requested.
                         properties:
                           required:
                             description: |-
-                              Required controls whether the related field must have at least one value.
+                              required controls whether the related field must have at least one value.
                               Defaults to `false`.
                             type: boolean
                           validations:
                             description: |-
-                              Validations applies rules using Common Expression Language (CEL) to
+                              validations applies rules using Common Expression Language (CEL) to
                               validate attribute values present on request beyond what is possible
                               to express using values/required.
                               ALL attribute values on the related CertificateRequest field must pass
@@ -772,7 +770,7 @@ spec:
                               properties:
                                 message:
                                   description: |-
-                                    Message is the message to display when validation fails.
+                                    message is the message to display when validation fails.
                                     Message is required if the Rule contains line breaks. Note that Message
                                     must not contain line breaks.
                                     If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -780,7 +778,7 @@ spec:
                                   type: string
                                 rule:
                                   description: |-
-                                    Rule represents the expression which will be evaluated by CEL.
+                                    rule represents the expression which will be evaluated by CEL.
                                     ref: https://github.com/google/cel-spec
                                     The Rule is scoped to the location of the validations in the schema.
                                     The `self` variable in the CEL expression is bound to the scoped value.
@@ -802,7 +800,7 @@ spec:
                             x-kubernetes-list-type: map
                           values:
                             description: |-
-                              Values defines allowed attribute values on the related CertificateRequest field.
+                              values defines allowed attribute values on the related CertificateRequest field.
                               Accepts wildcards "*".
                               If set, the related field can only include items contained in the allowed values.
 
@@ -813,17 +811,17 @@ spec:
                             type: array
                         type: object
                       provinces:
-                        description: Provinces defines the X.509 Subject Provinces
+                        description: provinces defines the X.509 Subject Provinces
                           that may be requested.
                         properties:
                           required:
                             description: |-
-                              Required controls whether the related field must have at least one value.
+                              required controls whether the related field must have at least one value.
                               Defaults to `false`.
                             type: boolean
                           validations:
                             description: |-
-                              Validations applies rules using Common Expression Language (CEL) to
+                              validations applies rules using Common Expression Language (CEL) to
                               validate attribute values present on request beyond what is possible
                               to express using values/required.
                               ALL attribute values on the related CertificateRequest field must pass
@@ -834,7 +832,7 @@ spec:
                               properties:
                                 message:
                                   description: |-
-                                    Message is the message to display when validation fails.
+                                    message is the message to display when validation fails.
                                     Message is required if the Rule contains line breaks. Note that Message
                                     must not contain line breaks.
                                     If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -842,7 +840,7 @@ spec:
                                   type: string
                                 rule:
                                   description: |-
-                                    Rule represents the expression which will be evaluated by CEL.
+                                    rule represents the expression which will be evaluated by CEL.
                                     ref: https://github.com/google/cel-spec
                                     The Rule is scoped to the location of the validations in the schema.
                                     The `self` variable in the CEL expression is bound to the scoped value.
@@ -864,7 +862,7 @@ spec:
                             x-kubernetes-list-type: map
                           values:
                             description: |-
-                              Values defines allowed attribute values on the related CertificateRequest field.
+                              values defines allowed attribute values on the related CertificateRequest field.
                               Accepts wildcards "*".
                               If set, the related field can only include items contained in the allowed values.
 
@@ -876,18 +874,18 @@ spec:
                         type: object
                       serialNumber:
                         description: |-
-                          SerialNumber defines the X.509 Subject Serial Number that may be
+                          serialNumber defines the X.509 Subject Serial Number that may be
                           requested.
                         properties:
                           required:
                             description: |-
-                              Required marks that the related field must be provided and not be an
+                              required marks that the related field must be provided and not be an
                               empty string.
                               Defaults to `false`.
                             type: boolean
                           validations:
                             description: |-
-                              Validations applies rules using Common Expression Language (CEL) to
+                              validations applies rules using Common Expression Language (CEL) to
                               validate attribute value present on request beyond what is possible
                               to express using value/required.
                               An attribute value on the related CertificateRequest field must pass
@@ -898,7 +896,7 @@ spec:
                               properties:
                                 message:
                                   description: |-
-                                    Message is the message to display when validation fails.
+                                    message is the message to display when validation fails.
                                     Message is required if the Rule contains line breaks. Note that Message
                                     must not contain line breaks.
                                     If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -906,7 +904,7 @@ spec:
                                   type: string
                                 rule:
                                   description: |-
-                                    Rule represents the expression which will be evaluated by CEL.
+                                    rule represents the expression which will be evaluated by CEL.
                                     ref: https://github.com/google/cel-spec
                                     The Rule is scoped to the location of the validations in the schema.
                                     The `self` variable in the CEL expression is bound to the scoped value.
@@ -928,7 +926,7 @@ spec:
                             x-kubernetes-list-type: map
                           value:
                             description: |-
-                              Value defines the allowed attribute value on the related CertificateRequest field.
+                              value defines the allowed attribute value on the related CertificateRequest field.
                               Accepts wildcards "*".
                               If set, the related field must match the specified pattern.
 
@@ -938,17 +936,17 @@ spec:
                         type: object
                       streetAddresses:
                         description: |-
-                          StreetAddresses defines the X.509 Subject Street Addresses that may be
+                          streetAddresses defines the X.509 Subject Street Addresses that may be
                           requested.
                         properties:
                           required:
                             description: |-
-                              Required controls whether the related field must have at least one value.
+                              required controls whether the related field must have at least one value.
                               Defaults to `false`.
                             type: boolean
                           validations:
                             description: |-
-                              Validations applies rules using Common Expression Language (CEL) to
+                              validations applies rules using Common Expression Language (CEL) to
                               validate attribute values present on request beyond what is possible
                               to express using values/required.
                               ALL attribute values on the related CertificateRequest field must pass
@@ -959,7 +957,7 @@ spec:
                               properties:
                                 message:
                                   description: |-
-                                    Message is the message to display when validation fails.
+                                    message is the message to display when validation fails.
                                     Message is required if the Rule contains line breaks. Note that Message
                                     must not contain line breaks.
                                     If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -967,7 +965,7 @@ spec:
                                   type: string
                                 rule:
                                   description: |-
-                                    Rule represents the expression which will be evaluated by CEL.
+                                    rule represents the expression which will be evaluated by CEL.
                                     ref: https://github.com/google/cel-spec
                                     The Rule is scoped to the location of the validations in the schema.
                                     The `self` variable in the CEL expression is bound to the scoped value.
@@ -989,7 +987,7 @@ spec:
                             x-kubernetes-list-type: map
                           values:
                             description: |-
-                              Values defines allowed attribute values on the related CertificateRequest field.
+                              values defines allowed attribute values on the related CertificateRequest field.
                               Accepts wildcards "*".
                               If set, the related field can only include items contained in the allowed values.
 
@@ -1001,16 +999,16 @@ spec:
                         type: object
                     type: object
                   uris:
-                    description: URIs defines the X.509 URI SANs that may be requested.
+                    description: uris defines the X.509 URI SANs that may be requested.
                     properties:
                       required:
                         description: |-
-                          Required controls whether the related field must have at least one value.
+                          required controls whether the related field must have at least one value.
                           Defaults to `false`.
                         type: boolean
                       validations:
                         description: |-
-                          Validations applies rules using Common Expression Language (CEL) to
+                          validations applies rules using Common Expression Language (CEL) to
                           validate attribute values present on request beyond what is possible
                           to express using values/required.
                           ALL attribute values on the related CertificateRequest field must pass
@@ -1021,7 +1019,7 @@ spec:
                           properties:
                             message:
                               description: |-
-                                Message is the message to display when validation fails.
+                                message is the message to display when validation fails.
                                 Message is required if the Rule contains line breaks. Note that Message
                                 must not contain line breaks.
                                 If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -1029,7 +1027,7 @@ spec:
                               type: string
                             rule:
                               description: |-
-                                Rule represents the expression which will be evaluated by CEL.
+                                rule represents the expression which will be evaluated by CEL.
                                 ref: https://github.com/google/cel-spec
                                 The Rule is scoped to the location of the validations in the schema.
                                 The `self` variable in the CEL expression is bound to the scoped value.
@@ -1051,7 +1049,7 @@ spec:
                         x-kubernetes-list-type: map
                       values:
                         description: |-
-                          Values defines allowed attribute values on the related CertificateRequest field.
+                          values defines allowed attribute values on the related CertificateRequest field.
                           Accepts wildcards "*".
                           If set, the related field can only include items contained in the allowed values.
 
@@ -1063,7 +1061,7 @@ spec:
                     type: object
                   usages:
                     description: |-
-                      Usages defines the key usages that may be included in a
+                      usages defines the key usages that may be included in a
                       CertificateRequest `spec.keyUsages` field.
                       If set, `spec.keyUsages` in a CertificateRequest must be a subset of the
                       specified values.
@@ -1128,14 +1126,14 @@ spec:
                 type: object
               constraints:
                 description: |-
-                  Constraints define fields that _must_ be satisfied by a
+                  constraints define fields that _must_ be satisfied by a
                   CertificateRequest for the request to be allowed by this policy.
                   Omitted fields place no restrictions on the corresponding
                   attribute in a request.
                 properties:
                   maxDuration:
                     description: |-
-                      MaxDuration defines the maximum duration for a certificate request.
+                      maxDuration defines the maximum duration for a certificate request.
                       Values are inclusive (i.e. a value of `1h` will accept a duration of
                       `1h`). MinDuration and MaxDuration may be the same value.
                       If set, a duration _must_ be requested in the CertificateRequest.
@@ -1143,7 +1141,7 @@ spec:
                     type: string
                   minDuration:
                     description: |-
-                      MinDuration defines the minimum duration for a certificate request.
+                      minDuration defines the minimum duration for a certificate request.
                       Values are inclusive (i.e. a value of `1h` will accept a duration of
                       `1h`). MinDuration and MaxDuration may be the same value.
                       If set, a duration _must_ be requested in the CertificateRequest.
@@ -1151,13 +1149,13 @@ spec:
                     type: string
                   privateKey:
                     description: |-
-                      PrivateKey defines constraints on the shape of private key
+                      privateKey defines constraints on the shape of private key
                       allowed for a CertificateRequest.
                       An omitted field applies no private key shape constraints.
                     properties:
                       algorithm:
                         description: |-
-                          Algorithm defines the allowed crypto algorithm for the private key
+                          algorithm defines the allowed crypto algorithm for the private key
                           in a request.
                           An omitted field permits any algorithm.
                         enum:
@@ -1167,14 +1165,14 @@ spec:
                         type: string
                       maxSize:
                         description: |-
-                          MaxSize defines the maximum key size for a private key.
+                          maxSize defines the maximum key size for a private key.
                           Values are inclusive (i.e. a min value of `2048` will accept a size
                           of `2048`). MaxSize and MinSize may be the same value.
                           An omitted field applies no maximum constraint on size.
                         type: integer
                       minSize:
                         description: |-
-                          MinSize defines the minimum key size for a private key.
+                          minSize defines the minimum key size for a private key.
                           Values are inclusive (i.e. a min value of `2048` will accept a size
                           of `2048`). MinSize and MaxSize may be the same value.
                           An omitted field applies no minimum constraint on size.
@@ -1191,13 +1189,13 @@ spec:
                       additionalProperties:
                         type: string
                       description: |-
-                        Values define a set of well-known, to the plugin, key value pairs that
+                        values define a set of well-known, to the plugin, key value pairs that
                         are required for the plugin to successfully evaluate a request based on
                         this policy.
                       type: object
                   type: object
                 description: |-
-                  Plugins are approvers that are built into approver-policy at
+                  plugins are approvers that are built into approver-policy at
                   compile-time. This is an advanced feature typically used to extend
                   approver-policy core features. This field define plugins and their
                   configuration that should be executed when this policy is evaluated
@@ -1205,13 +1203,13 @@ spec:
                 type: object
               selector:
                 description: |-
-                  Selector is used for selecting over which CertificateRequests this
+                  selector is used for selecting over which CertificateRequests this
                   CertificateRequestPolicy is appropriate for and so will be used for its
                   approval evaluation.
                 properties:
                   issuerRef:
                     description: |-
-                      IssuerRef is used to match by issuer, meaning the
+                      issuerRef is used to match by issuer, meaning the
                       CertificateRequestPolicy will only evaluate CertificateRequests
                       referring to matching issuers.
                       CertificateRequests will not be processed if the issuer does not match,
@@ -1224,21 +1222,21 @@ spec:
                     properties:
                       group:
                         description: |-
-                          Group is the wildcard selector to match the `spec.issuerRef.group` field
+                          group is the wildcard selector to match the `spec.issuerRef.group` field
                           on requests.
                           Accepts wildcards "*".
                           An omitted field matches all groups.
                         type: string
                       kind:
                         description: |-
-                          Kind is the wildcard selector to match the `spec.issuerRef.kind` field
+                          kind is the wildcard selector to match the `spec.issuerRef.kind` field
                           on requests.
                           Accepts wildcards "*".
                           An omitted field matches all kinds.
                         type: string
                       name:
                         description: |-
-                          Name is a wildcard enabled selector that matches the
+                          name is a wildcard enabled selector that matches the
                           `spec.issuerRef.name` field of requests.
                           Accepts wildcards "*".
                           An omitted field matches all names.
@@ -1246,7 +1244,7 @@ spec:
                     type: object
                   namespace:
                     description: |-
-                      Namespace is used to match by namespace, meaning the
+                      namespace is used to match by namespace, meaning the
                       CertificateRequestPolicy will only match CertificateRequests
                       created in matching namespaces.
                       If this field is omitted, resources in all namespaces are checked.
@@ -1255,13 +1253,13 @@ spec:
                         additionalProperties:
                           type: string
                         description: |-
-                          MatchLabels is the set of Namespace labels that select on
+                          matchLabels is the set of Namespace labels that select on
                           CertificateRequests which have been created in a namespace matching the
                           selector.
                         type: object
                       matchNames:
                         description: |-
-                          MatchNames is the set of namespace names that select on
+                          matchNames is the set of namespace names that select on
                           CertificateRequests that have been created in a matching namespace.
                           Accepts wildcards "*".
                         items:
@@ -1273,13 +1271,11 @@ spec:
             - selector
             type: object
           status:
-            description: |-
-              CertificateRequestPolicyStatus defines the observed state of the
-              CertificateRequestPolicy.
+            description: status is the observed state of the CertificateRequestPolicy.
             properties:
               conditions:
                 description: |-
-                  List of status conditions to indicate the status of the
+                  conditions is a list of status conditions to indicate the status of the
                   CertificateRequestPolicy.
                   Known condition types are `Ready`.
                 items:
@@ -1341,8 +1337,6 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
-        required:
-        - spec
         type: object
     served: true
     storage: true

--- a/klone.yaml
+++ b/klone.yaml
@@ -52,6 +52,11 @@ targets:
       repo_ref: main
       repo_hash: c2362005d2607bce04328c0557c5488c9d56812e
       repo_path: modules/klone
+    - folder_name: kube-api-linter
+      repo_url: https://github.com/cert-manager/makefile-modules.git
+      repo_ref: main
+      repo_hash: c2362005d2607bce04328c0557c5488c9d56812e
+      repo_path: modules/kube-api-linter
     - folder_name: licenses
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -36,6 +36,7 @@ helm_chart_version := $(VERSION)
 helm_labels_template_name := cert-manager-approver-policy.labels
 
 golangci_lint_config := .golangci.yaml
+kube_api_linter_config := .golangci.kube-api-linter.yaml
 
 define helm_values_mutation_function
 $(YQ) \

--- a/make/_shared/kube-api-linter/01_mod.mk
+++ b/make/_shared/kube-api-linter/01_mod.mk
@@ -1,0 +1,33 @@
+# Copyright 2026 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ifndef kube_api_linter_config
+$(error kube_api_linter_config is not set)
+endif
+
+kube_api_linter_timeout ?= 10m
+
+.PHONY: verify-kube-api-lint
+## Verify Kubernetes API types using Kube API Linter
+## @category [shared] Generate/ Verify
+verify-kube-api-lint: | $(NEEDS_GO) $(NEEDS_KUBE-API-LINTER)
+	GOVERSION=$(VENDORED_GO_VERSION) $(KUBE-API-LINTER) run -c $(CURDIR)/$(kube_api_linter_config) --timeout $(kube_api_linter_timeout)
+
+shared_verify_targets_dirty += verify-kube-api-lint
+
+.PHONY: fix-kube-api-lint
+## Fix Kubernetes API types using Kube API Linter
+## @category [shared] Generate/ Verify
+fix-kube-api-lint: | $(NEEDS_GO) $(NEEDS_KUBE-API-LINTER)
+	GOVERSION=$(VENDORED_GO_VERSION) $(KUBE-API-LINTER) run --fix -c $(CURDIR)/$(kube_api_linter_config) --timeout $(kube_api_linter_timeout)

--- a/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
+++ b/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
@@ -37,12 +37,15 @@ var CertificateRequestPolicyKind = "CertificateRequestPolicy"
 // or denied.
 type CertificateRequestPolicy struct {
 	metav1.TypeMeta `json:",inline"`
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// +optional
 	metav1.ObjectMeta `json:"metadata"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	Spec CertificateRequestPolicySpec `json:"spec"`
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// +optional
-	Status CertificateRequestPolicyStatus `json:"status,omitzero"`
+	Status CertificateRequestPolicyStatus `json:"status,omitzero"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -58,6 +61,7 @@ type CertificateRequestPolicyList struct {
 // CertificateRequestPolicySpec defines the desired state of
 // CertificateRequestPolicy.
 type CertificateRequestPolicySpec struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Allowed defines the allowed attributes for a CertificateRequest.
 	// A CertificateRequest can request _less_ than what is allowed,
 	// but _not more_, i.e. a CertificateRequest can request a subset of what
@@ -68,6 +72,7 @@ type CertificateRequestPolicySpec struct {
 	// +optional
 	Allowed *CertificateRequestPolicyAllowed `json:"allowed,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Constraints define fields that _must_ be satisfied by a
 	// CertificateRequest for the request to be allowed by this policy.
 	// Omitted fields place no restrictions on the corresponding
@@ -75,18 +80,20 @@ type CertificateRequestPolicySpec struct {
 	// +optional
 	Constraints *CertificateRequestPolicyConstraints `json:"constraints,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Plugins are approvers that are built into approver-policy at
 	// compile-time. This is an advanced feature typically used to extend
 	// approver-policy core features. This field define plugins and their
 	// configuration that should be executed when this policy is evaluated
 	// against a CertificateRequest.
 	// +optional
-	Plugins map[string]CertificateRequestPolicyPluginData `json:"plugins,omitempty"`
+	Plugins map[string]CertificateRequestPolicyPluginData `json:"plugins,omitempty"` //nolint:kubeapilinter // nomaps: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Selector is used for selecting over which CertificateRequests this
 	// CertificateRequestPolicy is appropriate for and so will be used for its
 	// approval evaluation.
-	Selector CertificateRequestPolicySelector `json:"selector"`
+	Selector CertificateRequestPolicySelector `json:"selector"` //nolint:kubeapilinter // nonpointerstructs: pre-existing API; changing it now could break clients, revisit for a future API version
 }
 
 // CertificateRequestPolicyAllowed defines the allowed attributes for a
@@ -97,26 +104,32 @@ type CertificateRequestPolicySpec struct {
 // Omitted fields declares that the equivalent CertificateRequest field _must_
 // be omitted or have an empty value for the request to be permitted.
 type CertificateRequestPolicyAllowed struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// CommonName defines the X.509 Common Name that may be requested.
 	// +optional
 	CommonName *CertificateRequestPolicyAllowedString `json:"commonName,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// DNSNames defines the X.509 DNS SANs that may be requested.
 	// +optional
 	DNSNames *CertificateRequestPolicyAllowedStringSlice `json:"dnsNames,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// IPAddresses defines the X.509 IP SANs that may be requested.
 	// +optional
 	IPAddresses *CertificateRequestPolicyAllowedStringSlice `json:"ipAddresses,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// URIs defines the X.509 URI SANs that may be requested.
 	// +optional
 	URIs *CertificateRequestPolicyAllowedStringSlice `json:"uris,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// EmailAddresses defines the X.509 Email SANs that may be requested.
 	// +optional
 	EmailAddresses *CertificateRequestPolicyAllowedStringSlice `json:"emailAddresses,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// IsCA defines if a CertificateRequest is allowed to set the `spec.isCA`
 	// field set to `true`.
 	// If `true`, the `spec.isCA` field can be `true` or `false`.
@@ -124,6 +137,7 @@ type CertificateRequestPolicyAllowed struct {
 	// +optional
 	IsCA *bool `json:"isCA,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Usages defines the key usages that may be included in a
 	// CertificateRequest `spec.keyUsages` field.
 	// If set, `spec.keyUsages` in a CertificateRequest must be a subset of the
@@ -131,8 +145,9 @@ type CertificateRequestPolicyAllowed struct {
 	// If `[]` or unset, no `spec.keyUsages` are allowed.
 	// TODO: add x-kubernetes-list-type: set in v1alpha2
 	// +optional
-	Usages *[]cmapi.KeyUsage `json:"usages,omitempty"`
+	Usages *[]cmapi.KeyUsage `json:"usages,omitempty"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Subject declares the X.509 Subject attributes allowed in a
 	// CertificateRequest. An omitted field forbids any Subject attributes
 	// from being requested.
@@ -141,6 +156,7 @@ type CertificateRequestPolicyAllowed struct {
 	// +optional
 	Subject *CertificateRequestPolicyAllowedX509Subject `json:"subject,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// OtherNames defines the additional SAN GeneralName otherName entries
 	// (context tag 0) that may be present in a CertificateRequest. Each
 	// entry pins a dotted ASN.1 OID (e.g. "1.3.6.1.4.1.311.20.2.3" for the
@@ -154,7 +170,7 @@ type CertificateRequestPolicyAllowed struct {
 	// +listType=map
 	// +listMapKey=oid
 	// +optional
-	OtherNames []CertificateRequestPolicyAllowedOtherName `json:"otherNames,omitempty"`
+	OtherNames []CertificateRequestPolicyAllowedOtherName `json:"otherNames,omitempty"` //nolint:kubeapilinter // arrayofstruct: pre-existing API; changing it now could break clients, revisit for a future API version
 }
 
 // CertificateRequestPolicyAllowedOtherName declares the allowed values for a
@@ -162,31 +178,35 @@ type CertificateRequestPolicyAllowed struct {
 // If neither Values nor Validations are specified, the related otherName
 // entry must be absent from the request.
 type CertificateRequestPolicyAllowedOtherName struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// OID is the dotted ASN.1 object identifier that the otherName entry
 	// must carry, e.g. "1.3.6.1.4.1.311.20.2.3" for the Microsoft User
 	// Principal Name.
-	OID string `json:"oid"`
+	OID string `json:"oid"` //nolint:kubeapilinter // optionalorrequired: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Values defines the allowed values for otherName entries with this
 	// OID. Accepts wildcards "*".
 	// If set, every otherName entry with the matching OID present in the
 	// request must be a member of this list.
 	// +optional
-	Values *[]string `json:"values,omitempty"`
+	Values *[]string `json:"values,omitempty"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Required marks that at least one otherName entry with this OID must
 	// be present on the request.
 	// Defaults to `false`.
 	// +optional
 	Required *bool `json:"required,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Validations applies rules using Common Expression Language (CEL) to
 	// validate every otherName value with the matching OID present on the
 	// request beyond what is possible to express using values/required.
 	// +listType=map
 	// +listMapKey=rule
 	// +optional
-	Validations []ValidationRule `json:"validations,omitempty"`
+	Validations []ValidationRule `json:"validations,omitempty"` //nolint:kubeapilinter // arrayofstruct: pre-existing API; changing it now could break clients, revisit for a future API version
 }
 
 // CertificateRequestPolicyAllowedX509Subject declares allowed X.509 Subject
@@ -194,42 +214,51 @@ type CertificateRequestPolicyAllowedOtherName struct {
 // A CertificateRequest can request a subset of the allowed X.509 Subject
 // attributes.
 type CertificateRequestPolicyAllowedX509Subject struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Organizations define the X.509 Subject Organizations that may be
 	// requested.
 	// +optional
 	Organizations *CertificateRequestPolicyAllowedStringSlice `json:"organizations,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Countries define the X.509 Subject Countries that may be requested.
 	// +optional
 	Countries *CertificateRequestPolicyAllowedStringSlice `json:"countries,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// OrganizationalUnits defines the X.509 Subject Organizational Units that
 	// may be requested.
 	// +optional
 	OrganizationalUnits *CertificateRequestPolicyAllowedStringSlice `json:"organizationalUnits,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Localities defines the X.509 Subject Localities that may be requested.
 	// +optional
 	Localities *CertificateRequestPolicyAllowedStringSlice `json:"localities,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Provinces defines the X.509 Subject Provinces that may be requested.
 	// +optional
 	Provinces *CertificateRequestPolicyAllowedStringSlice `json:"provinces,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// StreetAddresses defines the X.509 Subject Street Addresses that may be
 	// requested.
 	// +optional
 	StreetAddresses *CertificateRequestPolicyAllowedStringSlice `json:"streetAddresses,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// PostalCodes defines the X.509 Subject Postal Codes that may be requested.
 	// +optional
 	PostalCodes *CertificateRequestPolicyAllowedStringSlice `json:"postalCodes,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// SerialNumber defines the X.509 Subject Serial Number that may be
 	// requested.
 	// +optional
 	SerialNumber *CertificateRequestPolicyAllowedString `json:"serialNumber,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// OtherAttributes defines additional Subject RDN attribute OIDs that
 	// may be present in a CertificateRequest beyond the named fields above.
 	// Each entry pins a dotted ASN.1 OID (e.g. "1.2.840.113549.1.9.1" for
@@ -242,7 +271,7 @@ type CertificateRequestPolicyAllowedX509Subject struct {
 	// +listType=map
 	// +listMapKey=oid
 	// +optional
-	OtherAttributes []CertificateRequestPolicyAllowedSubjectOtherAttribute `json:"otherAttributes,omitempty"`
+	OtherAttributes []CertificateRequestPolicyAllowedSubjectOtherAttribute `json:"otherAttributes,omitempty"` //nolint:kubeapilinter // arrayofstruct: pre-existing API; changing it now could break clients, revisit for a future API version
 }
 
 // CertificateRequestPolicyAllowedSubjectOtherAttribute declares the allowed
@@ -251,23 +280,27 @@ type CertificateRequestPolicyAllowedX509Subject struct {
 // If neither Values nor Validations are specified, the related Subject RDN
 // attribute must be absent from the request.
 type CertificateRequestPolicyAllowedSubjectOtherAttribute struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// OID is the dotted ASN.1 object identifier of the Subject RDN
 	// attribute, e.g. "1.2.840.113549.1.9.1" for emailAddress.
-	OID string `json:"oid"`
+	OID string `json:"oid"` //nolint:kubeapilinter // optionalorrequired: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Values defines the allowed values for Subject RDN attributes with
 	// this OID. Accepts wildcards "*".
 	// If set, every Subject RDN attribute with the matching OID present in
 	// the request must be a member of this list.
 	// +optional
-	Values *[]string `json:"values,omitempty"`
+	Values *[]string `json:"values,omitempty"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Required marks that at least one Subject RDN attribute with this OID
 	// must be present on the request.
 	// Defaults to `false`.
 	// +optional
 	Required *bool `json:"required,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Validations applies rules using Common Expression Language (CEL) to
 	// validate every Subject RDN attribute value with the matching OID
 	// present on the request beyond what is possible to express using
@@ -275,13 +308,14 @@ type CertificateRequestPolicyAllowedSubjectOtherAttribute struct {
 	// +listType=map
 	// +listMapKey=rule
 	// +optional
-	Validations []ValidationRule `json:"validations,omitempty"`
+	Validations []ValidationRule `json:"validations,omitempty"` //nolint:kubeapilinter // arrayofstruct: pre-existing API; changing it now could break clients, revisit for a future API version
 }
 
 // CertificateRequestPolicyAllowedStringSlice represents allowed string values
 // and/or validations paired with whether the field is a required value on the request.
 // If neither allowed values nor validations are specified, the related field must be empty.
 type CertificateRequestPolicyAllowedStringSlice struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Values defines allowed attribute values on the related CertificateRequest field.
 	// Accepts wildcards "*".
 	// If set, the related field can only include items contained in the allowed values.
@@ -290,13 +324,15 @@ type CertificateRequestPolicyAllowedStringSlice struct {
 	// will never grant a `CertificateRequest`, but other policies may.
 	// TODO: add x-kubernetes-list-type: set in v1alpha2
 	// +optional
-	Values *[]string `json:"values,omitempty"`
+	Values *[]string `json:"values,omitempty"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Required controls whether the related field must have at least one value.
 	// Defaults to `false`.
 	// +optional
 	Required *bool `json:"required,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Validations applies rules using Common Expression Language (CEL) to
 	// validate attribute values present on request beyond what is possible
 	// to express using values/required.
@@ -305,13 +341,14 @@ type CertificateRequestPolicyAllowedStringSlice struct {
 	// +listType=map
 	// +listMapKey=rule
 	// +optional
-	Validations []ValidationRule `json:"validations,omitempty"`
+	Validations []ValidationRule `json:"validations,omitempty"` //nolint:kubeapilinter // arrayofstruct: pre-existing API; changing it now could break clients, revisit for a future API version
 }
 
 // CertificateRequestPolicyAllowedString represents an allowed string value
 // and/or validations paired with whether the field is a required value on the request.
 // If no allowed value nor validations are specified, the related field must be empty.
 type CertificateRequestPolicyAllowedString struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Value defines the allowed attribute value on the related CertificateRequest field.
 	// Accepts wildcards "*".
 	// If set, the related field must match the specified pattern.
@@ -321,12 +358,14 @@ type CertificateRequestPolicyAllowedString struct {
 	// +optional
 	Value *string `json:"value,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Required marks that the related field must be provided and not be an
 	// empty string.
 	// Defaults to `false`.
 	// +optional
 	Required *bool `json:"required,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Validations applies rules using Common Expression Language (CEL) to
 	// validate attribute value present on request beyond what is possible
 	// to express using value/required.
@@ -335,11 +374,12 @@ type CertificateRequestPolicyAllowedString struct {
 	// +listType=map
 	// +listMapKey=rule
 	// +optional
-	Validations []ValidationRule `json:"validations,omitempty"`
+	Validations []ValidationRule `json:"validations,omitempty"` //nolint:kubeapilinter // arrayofstruct: pre-existing API; changing it now could break clients, revisit for a future API version
 }
 
 // ValidationRule describes a validation rule expressed in CEL.
 type ValidationRule struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Rule represents the expression which will be evaluated by CEL.
 	// ref: https://github.com/google/cel-spec
 	// The Rule is scoped to the location of the validations in the schema.
@@ -352,8 +392,9 @@ type ValidationRule struct {
 	// ```
 	// rule: self.endsWith(cr.namespace + '.svc.cluster.local')
 	// ```
-	Rule string `json:"rule"`
+	Rule string `json:"rule"` //nolint:kubeapilinter // optionalorrequired: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Message is the message to display when validation fails.
 	// Message is required if the Rule contains line breaks. Note that Message
 	// must not contain line breaks.
@@ -368,22 +409,25 @@ type ValidationRule struct {
 // Omitted fields will be satisfied by any value in the corresponding attribute
 // of the request.
 type CertificateRequestPolicyConstraints struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// MinDuration defines the minimum duration for a certificate request.
 	// Values are inclusive (i.e. a value of `1h` will accept a duration of
 	// `1h`). MinDuration and MaxDuration may be the same value.
 	// If set, a duration _must_ be requested in the CertificateRequest.
 	// An omitted field applies no minimum constraint for duration.
 	// +optional
-	MinDuration *metav1.Duration `json:"minDuration,omitempty"`
+	MinDuration *metav1.Duration `json:"minDuration,omitempty"` //nolint:kubeapilinter // nodurations: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// MaxDuration defines the maximum duration for a certificate request.
 	// Values are inclusive (i.e. a value of `1h` will accept a duration of
 	// `1h`). MinDuration and MaxDuration may be the same value.
 	// If set, a duration _must_ be requested in the CertificateRequest.
 	// An omitted field applies no maximum constraint for duration.
 	// +optional
-	MaxDuration *metav1.Duration `json:"maxDuration,omitempty"`
+	MaxDuration *metav1.Duration `json:"maxDuration,omitempty"` //nolint:kubeapilinter // nodurations: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// PrivateKey defines constraints on the shape of private key
 	// allowed for a CertificateRequest.
 	// An omitted field applies no private key shape constraints.
@@ -394,30 +438,34 @@ type CertificateRequestPolicyConstraints struct {
 // CertificateRequestPolicyConstraintsPrivateKey defines constraints on the shape of private key
 // allowed for a CertificateRequest.
 type CertificateRequestPolicyConstraintsPrivateKey struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Algorithm defines the allowed crypto algorithm for the private key
 	// in a request.
 	// An omitted field permits any algorithm.
 	// +optional
 	Algorithm *cmapi.PrivateKeyAlgorithm `json:"algorithm,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// MinSize defines the minimum key size for a private key.
 	// Values are inclusive (i.e. a min value of `2048` will accept a size
 	// of `2048`). MinSize and MaxSize may be the same value.
 	// An omitted field applies no minimum constraint on size.
 	// +optional
-	MinSize *int `json:"minSize,omitempty"`
+	MinSize *int `json:"minSize,omitempty"` //nolint:kubeapilinter // integers: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// MaxSize defines the maximum key size for a private key.
 	// Values are inclusive (i.e. a min value of `2048` will accept a size
 	// of `2048`). MaxSize and MinSize may be the same value.
 	// An omitted field applies no maximum constraint on size.
 	// +optional
-	MaxSize *int `json:"maxSize,omitempty"`
+	MaxSize *int `json:"maxSize,omitempty"` //nolint:kubeapilinter // integers: pre-existing API; changing it now could break clients, revisit for a future API version
 }
 
 // CertificateRequestPolicyPluginData is configuration needed by the plugin
 // approver to evaluate a CertificateRequest on this policy.
 type CertificateRequestPolicyPluginData struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Values define a set of well-known, to the plugin, key value pairs that
 	// are required for the plugin to successfully evaluate a request based on
 	// this policy.
@@ -432,6 +480,7 @@ type CertificateRequestPolicyPluginData struct {
 // in order for the CertificateRequestPolicy to be chosen for evaluation.
 // At least one of IssuerRef or Namespace must be defined.
 type CertificateRequestPolicySelector struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// IssuerRef is used to match by issuer, meaning the
 	// CertificateRequestPolicy will only evaluate CertificateRequests
 	// referring to matching issuers.
@@ -443,19 +492,21 @@ type CertificateRequestPolicySelector struct {
 	// issuerRef: {}
 	// ```
 	// +optional
-	IssuerRef *CertificateRequestPolicySelectorIssuerRef `json:"issuerRef"`
+	IssuerRef *CertificateRequestPolicySelectorIssuerRef `json:"issuerRef"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Namespace is used to match by namespace, meaning the
 	// CertificateRequestPolicy will only match CertificateRequests
 	// created in matching namespaces.
 	// If this field is omitted, resources in all namespaces are checked.
 	// +optional
-	Namespace *CertificateRequestPolicySelectorNamespace `json:"namespace"`
+	Namespace *CertificateRequestPolicySelectorNamespace `json:"namespace"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 }
 
 // CertificateRequestPolicySelectorIssuerRef defines the selector for matching
 // the issuer reference of requests.
 type CertificateRequestPolicySelectorIssuerRef struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Name is a wildcard enabled selector that matches the
 	// `spec.issuerRef.name` field of requests.
 	// Accepts wildcards "*".
@@ -463,6 +514,7 @@ type CertificateRequestPolicySelectorIssuerRef struct {
 	// +optional
 	Name *string `json:"name,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Kind is the wildcard selector to match the `spec.issuerRef.kind` field
 	// on requests.
 	// Accepts wildcards "*".
@@ -470,6 +522,7 @@ type CertificateRequestPolicySelectorIssuerRef struct {
 	// +optional
 	Kind *string `json:"kind,omitempty"`
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// Group is the wildcard selector to match the `spec.issuerRef.group` field
 	// on requests.
 	// Accepts wildcards "*".
@@ -482,13 +535,15 @@ type CertificateRequestPolicySelectorIssuerRef struct {
 // the namespace of requests. Note that all selectors must match in order
 // for the request to be considered for evaluation by this policy.
 type CertificateRequestPolicySelectorNamespace struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// MatchNames is the set of namespace names that select on
 	// CertificateRequests that have been created in a matching namespace.
 	// Accepts wildcards "*".
 	// TODO: add x-kubernetes-list-type: set in v1alpha2
 	// +optional
-	MatchNames []string `json:"matchNames,omitempty"`
+	MatchNames []string `json:"matchNames,omitempty"` //nolint:kubeapilinter // ssatags: pre-existing API; changing it now could break clients, revisit for a future API version
 
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// MatchLabels is the set of Namespace labels that select on
 	// CertificateRequests which have been created in a namespace matching the
 	// selector.
@@ -499,13 +554,14 @@ type CertificateRequestPolicySelectorNamespace struct {
 // CertificateRequestPolicyStatus defines the observed state of the
 // CertificateRequestPolicy.
 type CertificateRequestPolicyStatus struct {
+	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
 	// List of status conditions to indicate the status of the
 	// CertificateRequestPolicy.
 	// Known condition types are `Ready`.
 	// +listType=map
 	// +listMapKey=type
 	// +optional
-	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"` //nolint:kubeapilinter // conditions: pre-existing API; changing it now could break clients, revisit for a future API version
 }
 
 const (

--- a/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
+++ b/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
@@ -42,8 +42,8 @@ type CertificateRequestPolicy struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	// spec is the desired state of the CertificateRequestPolicy.
-	// +optional
-	Spec CertificateRequestPolicySpec `json:"spec"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
+	// +required
+	Spec CertificateRequestPolicySpec `json:"spec"` //nolint:kubeapilinter // nonpointerstructs: spec has always been required; marking it optional would change the published CRD
 	// status is the observed state of the CertificateRequestPolicy.
 	// +optional
 	Status CertificateRequestPolicyStatus `json:"status,omitzero"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version

--- a/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
+++ b/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
@@ -81,7 +81,7 @@ type CertificateRequestPolicySpec struct {
 
 	// plugins are approvers that are built into approver-policy at
 	// compile-time. This is an advanced feature typically used to extend
-	// approver-policy core features. This field define plugins and their
+	// approver-policy core features. This field defines plugins and their
 	// configuration that should be executed when this policy is evaluated
 	// against a CertificateRequest.
 	// +optional
@@ -98,7 +98,7 @@ type CertificateRequestPolicySpec struct {
 // A CertificateRequest can request _less_ than what is allowed,
 // but _not more_, i.e. a CertificateRequest can request a subset of what is
 // declared as allowed by the policy.
-// Omitted fields declares that the equivalent CertificateRequest field _must_
+// Omitted fields declare that the equivalent CertificateRequest field _must_
 // be omitted or have an empty value for the request to be permitted.
 type CertificateRequestPolicyAllowed struct {
 	// commonName defines the X.509 Common Name that may be requested.

--- a/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
+++ b/pkg/apis/policy/v1alpha1/types_certificaterequestpolicy.go
@@ -37,13 +37,14 @@ var CertificateRequestPolicyKind = "CertificateRequestPolicy"
 // or denied.
 type CertificateRequestPolicy struct {
 	metav1.TypeMeta `json:",inline"`
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
+	// metadata is the standard object metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	Spec CertificateRequestPolicySpec `json:"spec"`
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
+	// spec is the desired state of the CertificateRequestPolicy.
+	// +optional
+	Spec CertificateRequestPolicySpec `json:"spec"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
+	// status is the observed state of the CertificateRequestPolicy.
 	// +optional
 	Status CertificateRequestPolicyStatus `json:"status,omitzero"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 }
@@ -61,8 +62,7 @@ type CertificateRequestPolicyList struct {
 // CertificateRequestPolicySpec defines the desired state of
 // CertificateRequestPolicy.
 type CertificateRequestPolicySpec struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Allowed defines the allowed attributes for a CertificateRequest.
+	// allowed defines the allowed attributes for a CertificateRequest.
 	// A CertificateRequest can request _less_ than what is allowed,
 	// but _not more_, i.e. a CertificateRequest can request a subset of what
 	// is declared as allowed by the policy.
@@ -72,16 +72,14 @@ type CertificateRequestPolicySpec struct {
 	// +optional
 	Allowed *CertificateRequestPolicyAllowed `json:"allowed,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Constraints define fields that _must_ be satisfied by a
+	// constraints define fields that _must_ be satisfied by a
 	// CertificateRequest for the request to be allowed by this policy.
 	// Omitted fields place no restrictions on the corresponding
 	// attribute in a request.
 	// +optional
 	Constraints *CertificateRequestPolicyConstraints `json:"constraints,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Plugins are approvers that are built into approver-policy at
+	// plugins are approvers that are built into approver-policy at
 	// compile-time. This is an advanced feature typically used to extend
 	// approver-policy core features. This field define plugins and their
 	// configuration that should be executed when this policy is evaluated
@@ -89,8 +87,7 @@ type CertificateRequestPolicySpec struct {
 	// +optional
 	Plugins map[string]CertificateRequestPolicyPluginData `json:"plugins,omitempty"` //nolint:kubeapilinter // nomaps: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Selector is used for selecting over which CertificateRequests this
+	// selector is used for selecting over which CertificateRequests this
 	// CertificateRequestPolicy is appropriate for and so will be used for its
 	// approval evaluation.
 	Selector CertificateRequestPolicySelector `json:"selector"` //nolint:kubeapilinter // nonpointerstructs: pre-existing API; changing it now could break clients, revisit for a future API version
@@ -104,41 +101,34 @@ type CertificateRequestPolicySpec struct {
 // Omitted fields declares that the equivalent CertificateRequest field _must_
 // be omitted or have an empty value for the request to be permitted.
 type CertificateRequestPolicyAllowed struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// CommonName defines the X.509 Common Name that may be requested.
+	// commonName defines the X.509 Common Name that may be requested.
 	// +optional
 	CommonName *CertificateRequestPolicyAllowedString `json:"commonName,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// DNSNames defines the X.509 DNS SANs that may be requested.
+	// dnsNames defines the X.509 DNS SANs that may be requested.
 	// +optional
 	DNSNames *CertificateRequestPolicyAllowedStringSlice `json:"dnsNames,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// IPAddresses defines the X.509 IP SANs that may be requested.
+	// ipAddresses defines the X.509 IP SANs that may be requested.
 	// +optional
 	IPAddresses *CertificateRequestPolicyAllowedStringSlice `json:"ipAddresses,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// URIs defines the X.509 URI SANs that may be requested.
+	// uris defines the X.509 URI SANs that may be requested.
 	// +optional
 	URIs *CertificateRequestPolicyAllowedStringSlice `json:"uris,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// EmailAddresses defines the X.509 Email SANs that may be requested.
+	// emailAddresses defines the X.509 Email SANs that may be requested.
 	// +optional
 	EmailAddresses *CertificateRequestPolicyAllowedStringSlice `json:"emailAddresses,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// IsCA defines if a CertificateRequest is allowed to set the `spec.isCA`
+	// isCA defines if a CertificateRequest is allowed to set the `spec.isCA`
 	// field set to `true`.
 	// If `true`, the `spec.isCA` field can be `true` or `false`.
 	// If `false` or unset, the `spec.isCA` field must be `false`.
 	// +optional
 	IsCA *bool `json:"isCA,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Usages defines the key usages that may be included in a
+	// usages defines the key usages that may be included in a
 	// CertificateRequest `spec.keyUsages` field.
 	// If set, `spec.keyUsages` in a CertificateRequest must be a subset of the
 	// specified values.
@@ -147,8 +137,7 @@ type CertificateRequestPolicyAllowed struct {
 	// +optional
 	Usages *[]cmapi.KeyUsage `json:"usages,omitempty"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Subject declares the X.509 Subject attributes allowed in a
+	// subject declares the X.509 Subject attributes allowed in a
 	// CertificateRequest. An omitted field forbids any Subject attributes
 	// from being requested.
 	// A CertificateRequest can request a subset of the allowed X.509 Subject
@@ -156,8 +145,7 @@ type CertificateRequestPolicyAllowed struct {
 	// +optional
 	Subject *CertificateRequestPolicyAllowedX509Subject `json:"subject,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// OtherNames defines the additional SAN GeneralName otherName entries
+	// otherNames defines the additional SAN GeneralName otherName entries
 	// (context tag 0) that may be present in a CertificateRequest. Each
 	// entry pins a dotted ASN.1 OID (e.g. "1.3.6.1.4.1.311.20.2.3" for the
 	// Microsoft User Principal Name) and constrains the allowed values for
@@ -178,29 +166,25 @@ type CertificateRequestPolicyAllowed struct {
 // If neither Values nor Validations are specified, the related otherName
 // entry must be absent from the request.
 type CertificateRequestPolicyAllowedOtherName struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// OID is the dotted ASN.1 object identifier that the otherName entry
+	// oid is the dotted ASN.1 object identifier that the otherName entry
 	// must carry, e.g. "1.3.6.1.4.1.311.20.2.3" for the Microsoft User
 	// Principal Name.
 	OID string `json:"oid"` //nolint:kubeapilinter // optionalorrequired: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Values defines the allowed values for otherName entries with this
+	// values defines the allowed values for otherName entries with this
 	// OID. Accepts wildcards "*".
 	// If set, every otherName entry with the matching OID present in the
 	// request must be a member of this list.
 	// +optional
 	Values *[]string `json:"values,omitempty"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Required marks that at least one otherName entry with this OID must
+	// required marks that at least one otherName entry with this OID must
 	// be present on the request.
 	// Defaults to `false`.
 	// +optional
 	Required *bool `json:"required,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Validations applies rules using Common Expression Language (CEL) to
+	// validations applies rules using Common Expression Language (CEL) to
 	// validate every otherName value with the matching OID present on the
 	// request beyond what is possible to express using values/required.
 	// +listType=map
@@ -214,52 +198,43 @@ type CertificateRequestPolicyAllowedOtherName struct {
 // A CertificateRequest can request a subset of the allowed X.509 Subject
 // attributes.
 type CertificateRequestPolicyAllowedX509Subject struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Organizations define the X.509 Subject Organizations that may be
+	// organizations define the X.509 Subject Organizations that may be
 	// requested.
 	// +optional
 	Organizations *CertificateRequestPolicyAllowedStringSlice `json:"organizations,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Countries define the X.509 Subject Countries that may be requested.
+	// countries define the X.509 Subject Countries that may be requested.
 	// +optional
 	Countries *CertificateRequestPolicyAllowedStringSlice `json:"countries,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// OrganizationalUnits defines the X.509 Subject Organizational Units that
+	// organizationalUnits defines the X.509 Subject Organizational Units that
 	// may be requested.
 	// +optional
 	OrganizationalUnits *CertificateRequestPolicyAllowedStringSlice `json:"organizationalUnits,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Localities defines the X.509 Subject Localities that may be requested.
+	// localities defines the X.509 Subject Localities that may be requested.
 	// +optional
 	Localities *CertificateRequestPolicyAllowedStringSlice `json:"localities,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Provinces defines the X.509 Subject Provinces that may be requested.
+	// provinces defines the X.509 Subject Provinces that may be requested.
 	// +optional
 	Provinces *CertificateRequestPolicyAllowedStringSlice `json:"provinces,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// StreetAddresses defines the X.509 Subject Street Addresses that may be
+	// streetAddresses defines the X.509 Subject Street Addresses that may be
 	// requested.
 	// +optional
 	StreetAddresses *CertificateRequestPolicyAllowedStringSlice `json:"streetAddresses,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// PostalCodes defines the X.509 Subject Postal Codes that may be requested.
+	// postalCodes defines the X.509 Subject Postal Codes that may be requested.
 	// +optional
 	PostalCodes *CertificateRequestPolicyAllowedStringSlice `json:"postalCodes,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// SerialNumber defines the X.509 Subject Serial Number that may be
+	// serialNumber defines the X.509 Subject Serial Number that may be
 	// requested.
 	// +optional
 	SerialNumber *CertificateRequestPolicyAllowedString `json:"serialNumber,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// OtherAttributes defines additional Subject RDN attribute OIDs that
+	// otherAttributes defines additional Subject RDN attribute OIDs that
 	// may be present in a CertificateRequest beyond the named fields above.
 	// Each entry pins a dotted ASN.1 OID (e.g. "1.2.840.113549.1.9.1" for
 	// emailAddress, "0.9.2342.19200300.100.1.25" for domainComponent) and
@@ -280,28 +255,24 @@ type CertificateRequestPolicyAllowedX509Subject struct {
 // If neither Values nor Validations are specified, the related Subject RDN
 // attribute must be absent from the request.
 type CertificateRequestPolicyAllowedSubjectOtherAttribute struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// OID is the dotted ASN.1 object identifier of the Subject RDN
+	// oid is the dotted ASN.1 object identifier of the Subject RDN
 	// attribute, e.g. "1.2.840.113549.1.9.1" for emailAddress.
 	OID string `json:"oid"` //nolint:kubeapilinter // optionalorrequired: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Values defines the allowed values for Subject RDN attributes with
+	// values defines the allowed values for Subject RDN attributes with
 	// this OID. Accepts wildcards "*".
 	// If set, every Subject RDN attribute with the matching OID present in
 	// the request must be a member of this list.
 	// +optional
 	Values *[]string `json:"values,omitempty"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Required marks that at least one Subject RDN attribute with this OID
+	// required marks that at least one Subject RDN attribute with this OID
 	// must be present on the request.
 	// Defaults to `false`.
 	// +optional
 	Required *bool `json:"required,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Validations applies rules using Common Expression Language (CEL) to
+	// validations applies rules using Common Expression Language (CEL) to
 	// validate every Subject RDN attribute value with the matching OID
 	// present on the request beyond what is possible to express using
 	// values/required.
@@ -315,8 +286,7 @@ type CertificateRequestPolicyAllowedSubjectOtherAttribute struct {
 // and/or validations paired with whether the field is a required value on the request.
 // If neither allowed values nor validations are specified, the related field must be empty.
 type CertificateRequestPolicyAllowedStringSlice struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Values defines allowed attribute values on the related CertificateRequest field.
+	// values defines allowed attribute values on the related CertificateRequest field.
 	// Accepts wildcards "*".
 	// If set, the related field can only include items contained in the allowed values.
 	//
@@ -326,14 +296,12 @@ type CertificateRequestPolicyAllowedStringSlice struct {
 	// +optional
 	Values *[]string `json:"values,omitempty"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Required controls whether the related field must have at least one value.
+	// required controls whether the related field must have at least one value.
 	// Defaults to `false`.
 	// +optional
 	Required *bool `json:"required,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Validations applies rules using Common Expression Language (CEL) to
+	// validations applies rules using Common Expression Language (CEL) to
 	// validate attribute values present on request beyond what is possible
 	// to express using values/required.
 	// ALL attribute values on the related CertificateRequest field must pass
@@ -348,8 +316,7 @@ type CertificateRequestPolicyAllowedStringSlice struct {
 // and/or validations paired with whether the field is a required value on the request.
 // If no allowed value nor validations are specified, the related field must be empty.
 type CertificateRequestPolicyAllowedString struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Value defines the allowed attribute value on the related CertificateRequest field.
+	// value defines the allowed attribute value on the related CertificateRequest field.
 	// Accepts wildcards "*".
 	// If set, the related field must match the specified pattern.
 	//
@@ -358,15 +325,13 @@ type CertificateRequestPolicyAllowedString struct {
 	// +optional
 	Value *string `json:"value,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Required marks that the related field must be provided and not be an
+	// required marks that the related field must be provided and not be an
 	// empty string.
 	// Defaults to `false`.
 	// +optional
 	Required *bool `json:"required,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Validations applies rules using Common Expression Language (CEL) to
+	// validations applies rules using Common Expression Language (CEL) to
 	// validate attribute value present on request beyond what is possible
 	// to express using value/required.
 	// An attribute value on the related CertificateRequest field must pass
@@ -379,8 +344,7 @@ type CertificateRequestPolicyAllowedString struct {
 
 // ValidationRule describes a validation rule expressed in CEL.
 type ValidationRule struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Rule represents the expression which will be evaluated by CEL.
+	// rule represents the expression which will be evaluated by CEL.
 	// ref: https://github.com/google/cel-spec
 	// The Rule is scoped to the location of the validations in the schema.
 	// The `self` variable in the CEL expression is bound to the scoped value.
@@ -394,8 +358,7 @@ type ValidationRule struct {
 	// ```
 	Rule string `json:"rule"` //nolint:kubeapilinter // optionalorrequired: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Message is the message to display when validation fails.
+	// message is the message to display when validation fails.
 	// Message is required if the Rule contains line breaks. Note that Message
 	// must not contain line breaks.
 	// If unset, a fallback message is used: "failed rule: `<rule>`".
@@ -409,8 +372,7 @@ type ValidationRule struct {
 // Omitted fields will be satisfied by any value in the corresponding attribute
 // of the request.
 type CertificateRequestPolicyConstraints struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// MinDuration defines the minimum duration for a certificate request.
+	// minDuration defines the minimum duration for a certificate request.
 	// Values are inclusive (i.e. a value of `1h` will accept a duration of
 	// `1h`). MinDuration and MaxDuration may be the same value.
 	// If set, a duration _must_ be requested in the CertificateRequest.
@@ -418,8 +380,7 @@ type CertificateRequestPolicyConstraints struct {
 	// +optional
 	MinDuration *metav1.Duration `json:"minDuration,omitempty"` //nolint:kubeapilinter // nodurations: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// MaxDuration defines the maximum duration for a certificate request.
+	// maxDuration defines the maximum duration for a certificate request.
 	// Values are inclusive (i.e. a value of `1h` will accept a duration of
 	// `1h`). MinDuration and MaxDuration may be the same value.
 	// If set, a duration _must_ be requested in the CertificateRequest.
@@ -427,8 +388,7 @@ type CertificateRequestPolicyConstraints struct {
 	// +optional
 	MaxDuration *metav1.Duration `json:"maxDuration,omitempty"` //nolint:kubeapilinter // nodurations: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// PrivateKey defines constraints on the shape of private key
+	// privateKey defines constraints on the shape of private key
 	// allowed for a CertificateRequest.
 	// An omitted field applies no private key shape constraints.
 	// +optional
@@ -438,23 +398,20 @@ type CertificateRequestPolicyConstraints struct {
 // CertificateRequestPolicyConstraintsPrivateKey defines constraints on the shape of private key
 // allowed for a CertificateRequest.
 type CertificateRequestPolicyConstraintsPrivateKey struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Algorithm defines the allowed crypto algorithm for the private key
+	// algorithm defines the allowed crypto algorithm for the private key
 	// in a request.
 	// An omitted field permits any algorithm.
 	// +optional
 	Algorithm *cmapi.PrivateKeyAlgorithm `json:"algorithm,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// MinSize defines the minimum key size for a private key.
+	// minSize defines the minimum key size for a private key.
 	// Values are inclusive (i.e. a min value of `2048` will accept a size
 	// of `2048`). MinSize and MaxSize may be the same value.
 	// An omitted field applies no minimum constraint on size.
 	// +optional
 	MinSize *int `json:"minSize,omitempty"` //nolint:kubeapilinter // integers: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// MaxSize defines the maximum key size for a private key.
+	// maxSize defines the maximum key size for a private key.
 	// Values are inclusive (i.e. a min value of `2048` will accept a size
 	// of `2048`). MaxSize and MinSize may be the same value.
 	// An omitted field applies no maximum constraint on size.
@@ -465,8 +422,7 @@ type CertificateRequestPolicyConstraintsPrivateKey struct {
 // CertificateRequestPolicyPluginData is configuration needed by the plugin
 // approver to evaluate a CertificateRequest on this policy.
 type CertificateRequestPolicyPluginData struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Values define a set of well-known, to the plugin, key value pairs that
+	// values define a set of well-known, to the plugin, key value pairs that
 	// are required for the plugin to successfully evaluate a request based on
 	// this policy.
 	// +optional
@@ -480,8 +436,7 @@ type CertificateRequestPolicyPluginData struct {
 // in order for the CertificateRequestPolicy to be chosen for evaluation.
 // At least one of IssuerRef or Namespace must be defined.
 type CertificateRequestPolicySelector struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// IssuerRef is used to match by issuer, meaning the
+	// issuerRef is used to match by issuer, meaning the
 	// CertificateRequestPolicy will only evaluate CertificateRequests
 	// referring to matching issuers.
 	// CertificateRequests will not be processed if the issuer does not match,
@@ -494,8 +449,7 @@ type CertificateRequestPolicySelector struct {
 	// +optional
 	IssuerRef *CertificateRequestPolicySelectorIssuerRef `json:"issuerRef"` //nolint:kubeapilinter // optionalfields: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Namespace is used to match by namespace, meaning the
+	// namespace is used to match by namespace, meaning the
 	// CertificateRequestPolicy will only match CertificateRequests
 	// created in matching namespaces.
 	// If this field is omitted, resources in all namespaces are checked.
@@ -506,24 +460,21 @@ type CertificateRequestPolicySelector struct {
 // CertificateRequestPolicySelectorIssuerRef defines the selector for matching
 // the issuer reference of requests.
 type CertificateRequestPolicySelectorIssuerRef struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Name is a wildcard enabled selector that matches the
+	// name is a wildcard enabled selector that matches the
 	// `spec.issuerRef.name` field of requests.
 	// Accepts wildcards "*".
 	// An omitted field matches all names.
 	// +optional
 	Name *string `json:"name,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Kind is the wildcard selector to match the `spec.issuerRef.kind` field
+	// kind is the wildcard selector to match the `spec.issuerRef.kind` field
 	// on requests.
 	// Accepts wildcards "*".
 	// An omitted field matches all kinds.
 	// +optional
 	Kind *string `json:"kind,omitempty"`
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// Group is the wildcard selector to match the `spec.issuerRef.group` field
+	// group is the wildcard selector to match the `spec.issuerRef.group` field
 	// on requests.
 	// Accepts wildcards "*".
 	// An omitted field matches all groups.
@@ -535,16 +486,14 @@ type CertificateRequestPolicySelectorIssuerRef struct {
 // the namespace of requests. Note that all selectors must match in order
 // for the request to be considered for evaluation by this policy.
 type CertificateRequestPolicySelectorNamespace struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// MatchNames is the set of namespace names that select on
+	// matchNames is the set of namespace names that select on
 	// CertificateRequests that have been created in a matching namespace.
 	// Accepts wildcards "*".
 	// TODO: add x-kubernetes-list-type: set in v1alpha2
 	// +optional
 	MatchNames []string `json:"matchNames,omitempty"` //nolint:kubeapilinter // ssatags: pre-existing API; changing it now could break clients, revisit for a future API version
 
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// MatchLabels is the set of Namespace labels that select on
+	// matchLabels is the set of Namespace labels that select on
 	// CertificateRequests which have been created in a namespace matching the
 	// selector.
 	// +optional
@@ -554,8 +503,7 @@ type CertificateRequestPolicySelectorNamespace struct {
 // CertificateRequestPolicyStatus defines the observed state of the
 // CertificateRequestPolicy.
 type CertificateRequestPolicyStatus struct {
-	//nolint:kubeapilinter // commentstart: rewording the godoc would change the published CRD field descriptions
-	// List of status conditions to indicate the status of the
+	// conditions is a list of status conditions to indicate the status of the
 	// CertificateRequestPolicy.
 	// Known condition types are `Ready`.
 	// +listType=map


### PR DESCRIPTION
Adopts the shared `kube-api-linter` module from cert-manager/makefile-modules#541 (now merged): `klone.yaml` klones the `kube-api-linter` module from makefile-modules `main` (same commit as the other modules), and `.golangci.kube-api-linter.yaml` scopes the linter to `pkg/apis`.

The linter reported 81 findings (the earlier "50" was golangci-lint's default 50-issue cap, which the config now lifts with `max-issues-per-linter: 0`). They are handled in two ways:

- 56 `commentstart` findings are **fixed** (third commit): the godoc now starts with each field's JSON name, mostly via `make fix-kube-api-lint`, plus hand-written godoc for `metadata`, `spec`, `status` and `conditions` which had none. The published CRD field descriptions change accordingly.
- 25 shape/marker findings (`optionalfields`, `arrayofstruct`, `nodurations`, `integers`, `nomaps`, `optionalorrequired`, `conditions`, `ssatags`, `nonpointerstructs`, `markers`) are **suppressed** with `//nolint:kubeapilinter` directives (second commit), following cert-manager/trust-manager#1080: fixing them would change the schema or Go types and could break existing clients; better revisited deliberately for a future API version.

Verified locally: `make verify-kube-api-lint` reports 0 issues and `make generate` / `go build` / `go vet` pass.

/hold

*with claude fable-5*
